### PR TITLE
Fix some joystick problems

### DIFF
--- a/PlayTools/Controls/PlayAction.swift
+++ b/PlayTools/Controls/PlayAction.swift
@@ -89,6 +89,7 @@ class JoystickAction : Action {
     func update(){
         if !mode.visible {
             var touch = center
+            var start = center
             if(GCKeyboard.pressed(key: keys[0])){
                 touch.y = touch.y - shift / 3
             } else if(GCKeyboard.pressed(key: keys[1])){
@@ -102,15 +103,21 @@ class JoystickAction : Action {
             if(moving){
                 if(touch.equalTo(center)){
                     moving = false
-                    Toucher.touchcam(point: touch, phase: UITouch.Phase.cancelled, tid: id)
+                    Toucher.touchcam(point: touch, phase: UITouch.Phase.ended, tid: id)
                 } else{
                     Toucher.touchcam(point: touch, phase: UITouch.Phase.moved, tid: id)
                 }
             } else{
-                moving = true
-                Toucher.touchcam(point: self.center, phase: UITouch.Phase.began, tid: id)
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.04) {
-                    Toucher.touchcam(point: touch, phase: UITouch.Phase.moved, tid: self.id)
+                if(!touch.equalTo(center)){
+                    moving = true
+                    start.x += (touch.x - start.x) / 8
+                    start.y += (touch.y - start.y) / 8
+                    Toucher.touchcam(point: start, phase: UITouch.Phase.began, tid: id)
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.04) {
+                        if(self.moving){
+                            Toucher.touchcam(point: touch, phase: UITouch.Phase.moved, tid: self.id)
+                        }
+                    }
                 }
                
             }

--- a/PlayTools/Controls/PlayAction.swift
+++ b/PlayTools/Controls/PlayAction.swift
@@ -109,9 +109,9 @@ class JoystickAction : Action {
                 }
             } else{
                 if(!touch.equalTo(center)){
-                    moving = true
                     start.x += (touch.x - start.x) / 8
                     start.y += (touch.y - start.y) / 8
+                    moving = true
                     Toucher.touchcam(point: start, phase: UITouch.Phase.began, tid: id)
                     DispatchQueue.main.asyncAfter(deadline: .now() + 0.04) {
                         if(self.moving){


### PR DESCRIPTION
This PR focuses on the following problems with the joystick control:

1. After using the joystick, when pressing option to call the cursor out, **a touch may be recognized** at the center of the joystick.
2. For Genshin, after using the joystick, after openning the in-game map using a mapped key (the M key normally) and pressing option to call the cursor out, the **map appears unable to be dragged**.
3. When pressing and releasing a joystick key very quickly (in less than 0.04s, according to the code), the pressed key is not released correctly, and **that key appears kept pressed**.
4. When the placement position of the joystick is not perfectly aligned with the in-game joystick, at the start of a joystick touch, the in-game joystick may shortly (for 0.04s, according to the code) **point to some certain direction** before pointing to the user-pressed direction.
5. If multiple joystick keys are pressed, when releasing them simutaneously (which I can reproduce in Genshin), the joystick is not released correctly. The in-game joystick may **keep pointing to some certain direction**.

The causes of these problems are the following:

1. The **touch phase of the joystick is never ended** unless pressing option to switch visible mode. At which time, a touch action with "ended" touch phase is sent, which lets the game think there is a touch completing at that point.
2. Instead of ending the touch phase, the joystick "cancels" it in react to user's release of joystick keys. That touch phase was designed for cases such as when the device is too close to the face to track touch actions, and does not necessarily mean that touch point has completed normally. Genshin's in-game map **always thinks there is a touch not released** at that point even after an "ended" phase is sent later, preventing the user to drag the map.
3. The joystick starts its touch from the center, and sets a scheduled task to move to the edge 0.04 seconds later. However, it is possible that before the scheduled task is executed, the user **had already released the key**. In which case, the following touch move action would never end.
4. Some touch-screen game joysticks are not expected to be pressed at the center. For Genshin, there is actually no joystick center: it can **always tell a direction** from your touch point. That's why the starting "center" touch of joystick becomes some other direction.
5. The code checks for a "keyReleased" event only when it thinks some key is being pressed. However, when two keys are released simutaneously, there will be two "keyReleased" events. The latter one **would start a new touch action** at the joystick center.

How the problems are solved:

1. Change the "cancelled" phase to "ended".
2. The same as above
3. Before executing the scheduled task, check whether the touch action had ended
4. Move the start point of a joystick touch some distance away from the center, towards the user-pressed direction
5. Check for "keyReleased" events even no key is being pressed.

The modifications have been tested for Genshin. More tests are welcome for other games or applications.

FAQ:

Q: Why would the original code use the "cancelled" phase instead of an "ended" phase? How dare you change this?
A: The original author may aim to avoid triggering a "moved" phase after an "ended" phase. While a "moved" phase after a "cancelled" phase may cause less problems. In my modifications, the "moved" phase is sent only when it determines the touch had not ended. So the "cancelled" phase can be safely replaced with "ended" phase.

Q: You still got race problems. What if another thread is executed between the check and the following commands?
A: That is true. I have arranged the sequence of commands so that this situation is less possible to be met.

Q: Why don't you use locks or atomic actions to completely eliminate race conditions?
A: In consider of the performance. Moreover, similar race conditions exist everywhere in other classes or functions. Solely solve them here does not help a lot. And from the practical perspective, I never met cases like that in real playing.

Q: Why do you write so much? I have a headache reading this shit.
A: Sorry I'm not good at explaining things but I'm trying to express it more clear. You could just read the code, which is simpler, and only look for explanations when something does not make sense.