### PR TITLE
Fix: disable toast user interaction

### DIFF
--- a/PlayTools/Utils/Toast.swift
+++ b/PlayTools/Utils/Toast.swift
@@ -20,6 +20,7 @@ class Toast {
         toastContainer.alpha = 0.0
         toastContainer.layer.cornerRadius = 25;
         toastContainer.clipsToBounds  =  true
+        toastContainer.isUserInteractionEnabled = false
 
         let toastLabel = UILabel(frame: CGRect())
         toastLabel.textColor = UIColor.white


### PR DESCRIPTION
A toast is the message area that appears at the bottom of the window to show you a line of text when you do some action. For example, when you click cmd+k to open keymapping editor mode, a toast is displayed telling you "Click to start keymapping edit".
<img width="1048" alt="图片" src="https://user-images.githubusercontent.com/16048758/182856060-23c0a1d9-952a-4a33-a85e-d0eecb7cdb5c.png">
Based on the functionality of a toast, we think that a toast does not receive user interactions, but only shows messages. However, the play tool's toast does receive user interactions, making the elements behind it, including the game, unable to receive touch events.

For example, consider the game and keymapping shown in the image above. The toast area is on top of the mapped "RMB", "E", "Q" and "Z" keys. When the keymapping editor mode is closed, a toast saing "Keymapping saved" appears. Before that toast disappears (which takes 2.5 seconds), these keys are unable to operate.

The fix simply sets the `isUserInteractionEnabled` property of the UIView object of the toast to false.