### PR TITLE
Fix editor mode switching and command Q

### DIFF
--- a/PlayTools/Controls/PlayAction.swift
+++ b/PlayTools/Controls/PlayAction.swift
@@ -35,7 +35,7 @@ class ButtonAction : Action {
         if let keyboard = GCKeyboard.coalesced?.keyboardInput {
             if !PlayMice.shared.setMiceButtons(keyid, action: self){
                 keyboard.button(forKeyCode: key)?.pressedChangedHandler = { (key, keyCode, pressed) in
-                    if !mode.visible {
+                    if !mode.visible && !PlayInput.cmdPressed(){
                         self.update(pressed: pressed)
                     }
                 }

--- a/PlayTools/Keymap/EditorController.swift
+++ b/PlayTools/Keymap/EditorController.swift
@@ -8,6 +8,8 @@ final class EditorController : NSObject {
     
     static let shared = EditorController()
     
+    let lock = NSLock()
+    
     var focusedControl : ControlModel? = nil
     
     var controls : Array<ControlModel> = []
@@ -32,31 +34,29 @@ final class EditorController : NSObject {
         }
     }
     
-    var isReadyToBeOpened = true
-    
     public func switchMode(){
+        lock.lock()
         if EditorController.shared.editorMode {
             Toast.showOver(msg: "Keymapping saved")
         } else{
             Toast.showOver(msg: "Click to start keymmaping edit")
         }
+        
         if editorMode {
             KeymapHolder.shared.hide()
             saveButtons()
             view.removeFromSuperview()
             editorMode = false
             mode.show(false)
-            PlayCover.delay(0.1) {
-                self.isReadyToBeOpened = true
-            }
+            focusedControl = nil
         } else{
             mode.show(true)
             editorMode = true
             showButtons()
             screen.window?.addSubview(view)
             view.becomeFirstResponder()
-            self.isReadyToBeOpened = false
         }
+        lock.unlock()
     }
     
     var editorMode : Bool {


### PR DESCRIPTION
This PR aims to solve the following problems:

1. When keymapping is enabled, cmd+Q does not work.
2. When switching keymapping editor mode, it often triggers multiple consecutive switchings.

By solving problem 1, this PR actually makes every command combination keys usable under keymapping mode, including cmd+Q, cmd+W and menu shortcuts.

The direct cause of the cmd+Q problem is the `fixBeepSound()` function inside playInput. 
## Parallel Event Chains

As far as I can understand, the way playTools handle keyboard input is out of the typical event framework. In the typical framework, event handlers form a chain. If one handler does not handle an event, that event is passed to the next handler. If no handler claims to handle an event, the framework knows this and emits a "Beep" sound to indicate this key press is invalid. As the keyboard handler of playTools is not in this framework, the framework does not know that the pressing event has been handled, and will still emit that "Beep" sound. 

## Fix Beep Sound

To solve this, the original author inserts an empty keyboard event handler into the framework, eating that redundant event to mute that "Beep" sound, when keymapping is enabled. (the `fixBeepSound()` in PlayInput.swift) It also eats the command key pressing events, which are actually not handled by playTools.

## Cmd+K Handler

But how is cmd+K able to respond when keymapping is enabled? In fact, the original author made another event handler that is dedicated to handling cmd+K under keymapping mode (PlayInput.swift:36). So the situation is, there are actually two cmd+K responders: one is the menu shortcut, the other is that keymapping-mode-only handler. The problem is, the two handlers do not have clear borders. That is, they sometimes respond at the same time. 

## Editor Mode Switch Cooldown

To make things worse, that hand-crafted cmd+K handler reacts to both key pressed and key released events. The only reason you can still switch editor mode is a 0.1s cooldown, within which the editor mode cannot be switched by the hand-crafted handler. But this cooldown does not limit the switch from menu shortcut. That's why the editor mode sometimes closes immediately after it is opened.

## Fix

The fix is not complicated. Just check for command key presses in that `fixBeepSound` function, and let that event continue its trip if command is pressed. The extra cmd+K handler is deleted, since all command key shortcuts can now be directly triggered. 

Additionally, some corner cases are handled, including invalidating keymapping editor focus when closed, invalidating mapped keys when cmd pressed, etc.

## Further Improvement

The original way of checking cmd pressed is inefficient. I instead maintain the command key pressing status, and alters it when cmd key is pressed or released.

Also, the `fixBeepSound` function name is changed to be more understandable. I also try to eliminate the magic number `1024`, but that dynamic reflection bit me. I cannot get the property path correct. Finally gave up. Wrong property path does not emit any error, but silently causes weird problems, which confused me for days before I decided to bisect my changed code.


