### PR TITLE
Fix ESC and function keys mappings cannot be added

### DIFF
--- a/PlayTools/Controls/PlayInput.swift
+++ b/PlayTools/Controls/PlayInput.swift
@@ -62,17 +62,11 @@ final class PlayInput: NSObject {
        }
     
     private static let FORBIDDEN : [GCKeyCode] = [
-        GCKeyCode.init(rawValue: 227),
-        GCKeyCode.init(rawValue: 231),
+        GCKeyCode.init(rawValue: 227), // LCmd
+        GCKeyCode.init(rawValue: 231), // RCmd
         .leftAlt,
         .rightAlt,
-        .escape,
-        .printScreen,
-        .F1,
-        .F2,
-        .F3,
-        .F4,
-        .F5
+        .printScreen
     ]
     
     private func swapMode(_ pressed : Bool){


### PR DESCRIPTION
Fixes https://github.com/PlayCover/PlayCover/issues/145

ESC key and function keys have long been used as mapped keys in official keymaps for games like Genshin, yet manually binding them is still impossible. The cause is simply a forbid list that explictly forbids binding of these keys. 

The reason why these keys are forbidden is unclear. That forbid list has not been altered since first commit from iVoider. Since people are already binding these keys by directly editing the keymapping file, this change should not introduce more problems.