### PR TITLE
Adding Ipad model switcher

### DIFF
--- a/PlayTools/PlayLoader.m
+++ b/PlayTools/PlayLoader.m
@@ -32,17 +32,21 @@ extern void *dyld_get_base_platform(void *platform);
 void *my_dyld_get_base_platform(void *platform) { return 2; }
 
 // #define DEVICE_MODEL ("iPad13,8")
-#define DEVICE_MODEL ("iPad8,6")
+//#define DEVICE_MODEL ("iPad8,6")
 
 // find Mac by using sysctl of HW_TARGET
 // #define OEM_ID ("J522AP")
-#define OEM_ID ("J320xAP")
+// #define OEM_ID ("J320xAP")
+
+// get device model from playcover .plist
+#define DEVICE_MODEL ([[[PlaySettings shared] GET_IPAD_MODEL] UTF8String])
+#define OEM_ID ([[[PlaySettings shared] GET_OEM_ID] UTF8String])
 
 static int my_uname(struct utsname *uts) {
   int result = 0;
-  NSString *nickname = @"ipad";
-//   NSString *productType = @"iPad13,8";
-  NSString *productType = @"iPad8,6";
+    NSString *nickname = @"ipad";
+  //   NSString *productType = @"iPad13,8";
+    NSString *productType =  [[PlaySettings shared] GET_IPAD_MODEL];
   if (nickname.length == 0)
     result = uname(uts);
   else {
@@ -150,6 +154,7 @@ extern int csops(pid_t pid, unsigned int ops, void *useraddr, size_t usersize);
 int my_csops(pid_t pid, uint32_t ops, user_addr_t useraddr, user_size_t usersize) {
   if (isGenshin) {
     if (ops == CS_OPS_STATUS || ops == CS_OPS_IDENTITY) {
+      printf("Hooking %s : %s \n", DEVICE_MODEL, OEM_ID);
       printf("Hooked CSOPS %d \n", ops);
       return 0;
     }

--- a/PlayTools/PlayLoader.m
+++ b/PlayTools/PlayLoader.m
@@ -44,14 +44,12 @@ void *my_dyld_get_base_platform(void *platform) { return 2; }
 
 static int my_uname(struct utsname *uts) {
   int result = 0;
-    NSString *nickname = @"ipad";
-  //   NSString *productType = @"iPad13,8";
-    NSString *productType =  [[PlaySettings shared] GET_IPAD_MODEL];
+  NSString *nickname = @"ipad";
   if (nickname.length == 0)
     result = uname(uts);
   else {
     strncpy(uts->nodename, [nickname UTF8String], nickname.length + 1);
-    strncpy(uts->machine, [productType UTF8String], productType.length + 1);
+    strncpy(uts->machine, DEVICE_MODEL, strlen(DEVICE_MODEL) + 1);
   }
   return result;
 }
@@ -154,7 +152,7 @@ extern int csops(pid_t pid, unsigned int ops, void *useraddr, size_t usersize);
 int my_csops(pid_t pid, uint32_t ops, user_addr_t useraddr, user_size_t usersize) {
   if (isGenshin) {
     if (ops == CS_OPS_STATUS || ops == CS_OPS_IDENTITY) {
-      printf("Hooking %s : %s \n", DEVICE_MODEL, OEM_ID);
+      printf("Hooking %s: %s wrapper \n", DEVICE_MODEL, OEM_ID);
       printf("Hooked CSOPS %d \n", ops);
       return 0;
     }

--- a/PlayTools/PlaySettings.swift
+++ b/PlayTools/PlaySettings.swift
@@ -115,6 +115,30 @@ extension Dictionary {
         }
         return 1920.0
     }()
+    
+    private static let ipadModelKey = "pc.ipadModel"
+    @objc lazy public var GET_IPAD_MODEL : NSString = {
+        if let key = settings[PlaySettings.ipadModelKey] as? NSString {
+            return key
+        }
+        return "iPad8,6"
+    }()
+    
+    @objc lazy public var GET_OEM_ID : NSString = {
+        if let key = settings[PlaySettings.ipadModelKey] as? NSString {
+            switch (key) {
+                case "iPad6,7":
+                    return "J98aAP"
+                case "iPad8,6":
+                    return "J320xAP"
+                case "iPad13,8":
+                    return "J522AP"
+                default:
+                    return "J320xAP"
+            }
+        }
+        return "J320xAP"
+    }()
 
     static var isGame : Bool {
         if let info = Bundle.main.infoDictionary?.description{


### PR DESCRIPTION
This Pull request aims to change the Ipad model identifier by reading pc.ipadModel key value on playcover.plist.