### PR TITLE
gracefully terminate the game when close window

### DIFF
--- a/PlayTools/PlayCover.swift
+++ b/PlayTools/PlayCover.swift
@@ -33,7 +33,7 @@ final public class PlayCover : NSObject {
             queue: OperationQueue.main
         ) { noti in
             if PlayScreen.shared.nsWindow?.isEqual(noti.object) ?? false {
-                exit(0)
+                Dynamic.NSApplication.sharedApplication.terminate(self)
             }
         }
     }


### PR DESCRIPTION
Existing code uses `exit(0)` to terminate the app when its window is closed. This may miss some termination jobs that may be essential to some games. See the discussions [here.](https://stackoverflow.com/questions/25258424/difference-between-ways-to-quit-an-application-exit-nsapp-nsapplication-term)

The method proposed here is also used at `PlayUI.swift:25`. So it has a good chance to be OK.