### PR TITLE
Optimize performance of PTFakeTouch

### DIFF
--- a/PlayTools/Controls/PTFakeTouch/PTFakeMetaTouch.h
+++ b/PlayTools/Controls/PTFakeTouch/PTFakeMetaTouch.h
@@ -19,25 +19,26 @@ typedef struct {
 double ColourDistance(RGB e1, RGB e2);
 
 @interface PTFakeMetaTouch : NSObject
-/**
- *  Fake a touch event 构造一个触屏基础操作
- *
- *  @param pointId 触屏操作的序列号
- *  @param point   操作的目的位置
- *  @param phase   操作的类别
- *
- *  @return pointId 返回操作的序列号
- */
-
 + (void)load;
 
 + (UITouch* ) touch: (NSInteger) pointId;
 
-+ (NSInteger)fakeTouchId:(NSInteger)pointId AtPoint:(CGPoint)point withTouchPhase:(UITouchPhase)phase;
 /**
- *  Get a not used pointId 获取一个没有使用过的触屏序列号
+ *  Fake a touch event 构造一个触屏基础操作 construct a touchscreen basic operation
  *
- *  @return pointId 返回序列号
+ *  @param pointId 触屏操作的序列号 sequence number of touch screen operation
+ *  @param point   操作的目的位置 target position of the operation
+ *  @param phase   操作的类别 type of the operation
+ *  @param window  key window in which touch event is to happen
+ *
+ *  @return pointId 返回操作的序列号 returns sequence number of the operation
+ */
+
++ (NSInteger)fakeTouchId:(NSInteger)pointId AtPoint:(CGPoint)point withTouchPhase:(UITouchPhase)phase inWindow:(UIWindow*)window;
+/**
+ *  Get a not used pointId 获取一个没有使用过的触屏序列号 obtain a never used touch screen sequence number
+ *
+ *  @return pointId 返回序列号 returns sequence number
  */
 + (NSInteger)getAvailablePointId;
 

--- a/PlayTools/Controls/PTFakeTouch/PTFakeMetaTouch.h
+++ b/PlayTools/Controls/PTFakeTouch/PTFakeMetaTouch.h
@@ -31,7 +31,7 @@ double ColourDistance(RGB e1, RGB e2);
  *  @param phase   操作的类别 type of the operation
  *  @param window  key window in which touch event is to happen
  *
- *  @return pointId 返回操作的序列号 returns sequence number of the operation
+ *  @return realid returns the allocated ID for this touch point, or -1 if no such point
  */
 
 + (NSInteger)fakeTouchId:(NSInteger)pointId AtPoint:(CGPoint)point withTouchPhase:(UITouchPhase)phase inWindow:(UIWindow*)window;

--- a/PlayTools/Controls/PTFakeTouch/PTFakeMetaTouch.m
+++ b/PlayTools/Controls/PTFakeTouch/PTFakeMetaTouch.m
@@ -78,21 +78,22 @@ void moveCursorTo(CGPoint point){
     return nil;
 }
 
-+ (NSInteger)fakeTouchId:(NSInteger)pointId AtPoint:(CGPoint)point withTouchPhase:(UITouchPhase)phase{
++ (NSInteger)fakeTouchId:(NSInteger)pointId AtPoint:(CGPoint)point withTouchPhase:(UITouchPhase)phase inWindow:(UIWindow*)window{
     pointId = pointId - 1;
     UITouch *touch = [touchAry objectAtIndex:pointId];
     if (phase == UITouchPhaseBegan) {
         touch = nil;
-        touch = [[UITouch alloc] initAtPoint:point inWindow:[UIApplication sharedApplication].keyWindow];
+        touch = [[UITouch alloc] initAtPoint:point inWindow:window];
         
-#warning - Keyboard -
-        //// Keyboard FIX: Artem Levkovich, ITRex Group: http://itrexgroup.com
-        CGRect keyboardFrame;
-        // AppDelegate *appDelegate = (AppDelegate *)[[UIApplication sharedApplication] delegate];
-        // keyboardFrame = appDelegate.keyboardFrame; (get keyboard frame using UIKeyboardDidShowNotification)
-        if([[[UIApplication sharedApplication].windows lastObject] isKindOfClass:NSClassFromString(@"UIRemoteKeyboardWindow")] && (CGRectContainsPoint(CGRectMake(0, [UIApplication sharedApplication].keyWindow.frame.size.height-keyboardFrame.size.height, [UIApplication sharedApplication].keyWindow.frame.size.width, keyboardFrame.size.height), point))) {
-            touch = [[UITouch alloc] initAtPoint:point inWindow:[[UIApplication sharedApplication].windows lastObject]];
-        }
+        // Xyct: commented out, cause this would crash once executed
+//#warning - Keyboard -
+//        //// Keyboard FIX: Artem Levkovich, ITRex Group: http://itrexgroup.com
+//        CGRect keyboardFrame;
+//        // AppDelegate *appDelegate = (AppDelegate *)[[UIApplication sharedApplication] delegate];
+//        // keyboardFrame = appDelegate.keyboardFrame; (get keyboard frame using UIKeyboardDidShowNotification)
+//        if([[[UIApplication sharedApplication].windows lastObject] isKindOfClass:NSClassFromString(@"UIRemoteKeyboardWindow")] && (CGRectContainsPoint(CGRectMake(0, [UIApplication sharedApplication].keyWindow.frame.size.height-keyboardFrame.size.height, [UIApplication sharedApplication].keyWindow.frame.size.width, keyboardFrame.size.height), point))) {
+//            touch = [[UITouch alloc] initAtPoint:point inWindow:[[UIApplication sharedApplication].windows lastObject]];
+//        }
         
         [touchAry replaceObjectAtIndex:pointId withObject:touch];
         [touch setLocationInWindow:point];

--- a/PlayTools/Controls/PTFakeTouch/PTFakeMetaTouch.m
+++ b/PlayTools/Controls/PTFakeTouch/PTFakeMetaTouch.m
@@ -13,6 +13,7 @@
 #include <dlfcn.h>
 
 static NSMutableArray *touchAry;
+static NSMutableArray *livingTouchAry;
 
 void disableCursor(boolean_t disable){
        void *handle;
@@ -63,6 +64,7 @@ void moveCursorTo(CGPoint point){
 + (void)load{
     KW_ENABLE_CATEGORY(UITouch_KIFAdditions);
     KW_ENABLE_CATEGORY(UIEvent_KIFAdditions);
+    livingTouchAry = [[NSMutableArray alloc] init];
     touchAry = [[NSMutableArray alloc] init];
     for (NSInteger i = 0; i< 100; i++) {
         UITouch *touch = [[UITouch alloc] initTouch];
@@ -79,35 +81,35 @@ void moveCursorTo(CGPoint point){
 }
 
 + (NSInteger)fakeTouchId:(NSInteger)pointId AtPoint:(CGPoint)point withTouchPhase:(UITouchPhase)phase inWindow:(UIWindow*)window{
-    pointId = pointId - 1;
-    UITouch *touch = [touchAry objectAtIndex:pointId];
-    if (phase == UITouchPhaseBegan) {
-        touch = nil;
-        touch = [[UITouch alloc] initAtPoint:point inWindow:window];
-        
-        // Xyct: commented out, cause this would crash once executed
-//#warning - Keyboard -
-//        //// Keyboard FIX: Artem Levkovich, ITRex Group: http://itrexgroup.com
-//        CGRect keyboardFrame;
-//        // AppDelegate *appDelegate = (AppDelegate *)[[UIApplication sharedApplication] delegate];
-//        // keyboardFrame = appDelegate.keyboardFrame; (get keyboard frame using UIKeyboardDidShowNotification)
-//        if([[[UIApplication sharedApplication].windows lastObject] isKindOfClass:NSClassFromString(@"UIRemoteKeyboardWindow")] && (CGRectContainsPoint(CGRectMake(0, [UIApplication sharedApplication].keyWindow.frame.size.height-keyboardFrame.size.height, [UIApplication sharedApplication].keyWindow.frame.size.width, keyboardFrame.size.height), point))) {
-//            touch = [[UITouch alloc] initAtPoint:point inWindow:[[UIApplication sharedApplication].windows lastObject]];
-//        }
-        
-        [touchAry replaceObjectAtIndex:pointId withObject:touch];
-        [touch setLocationInWindow:point];
-    }else{
-        [touch setLocationInWindow:point];
+    pointId -= 1;
+    // ideally should be phase began when this hit
+    // but if by any means other phases come... well lets be forgiving
+    NSUInteger livingIndex = [livingTouchAry indexOfObjectIdenticalTo:touchAry[pointId]];
+    if(livingIndex == NSNotFound) {
+        if(phase == UITouchPhaseEnded) return -1;
+        UITouch *touch = [[UITouch alloc] initAtPoint:point inWindow:window];
+        livingIndex = livingTouchAry.count;
+        [livingTouchAry addObject:touch];
+        [touchAry setObject:touch atIndexedSubscript:pointId ];
+    }
+    UITouch *touch = [livingTouchAry objectAtIndex:livingIndex];
+    
+    [touch setLocationInWindow:point];
+    if(touch.phase!=UITouchPhaseBegan){
         [touch setPhaseAndUpdateTimestamp:phase];
     }
     
-    UIEvent *event = [self eventWithTouches:touchAry];
+    UIEvent *event = [self eventWithTouches:livingTouchAry];
     [[UIApplication sharedApplication] sendEvent:event];
     if ((touch.phase==UITouchPhaseBegan)||touch.phase==UITouchPhaseMoved) {
         [touch setPhaseAndUpdateTimestamp:UITouchPhaseStationary];
     }
-    return (pointId+1);
+    
+    if (phase == UITouchPhaseEnded) {
+        [livingTouchAry removeObjectAtIndex:livingIndex];
+//        [touchAry removeObjectAtIndex:pointId];
+    }
+    return livingIndex;
 }
 
 

--- a/PlayTools/Controls/PTFakeTouch/PTFakeMetaTouch.m
+++ b/PlayTools/Controls/PTFakeTouch/PTFakeMetaTouch.m
@@ -101,7 +101,6 @@ void moveCursorTo(CGPoint point){
     
 //    UIEvent *event = [self eventWithTouches:livingTouchAry];
     UIEvent *event = [[UIApplication sharedApplication] _touchesEvent];
-    [event kif_setEventWithTouches:livingTouchAry];
     dispatch_sync(dispatch_get_main_queue(), ^{
         [event _clearTouches];
         for (UITouch *aTouch in livingTouchAry) {

--- a/PlayTools/Controls/PTFakeTouch/PTFakeMetaTouch.m
+++ b/PlayTools/Controls/PTFakeTouch/PTFakeMetaTouch.m
@@ -99,8 +99,16 @@ void moveCursorTo(CGPoint point){
         [touch setPhaseAndUpdateTimestamp:phase];
     }
     
-    UIEvent *event = [self eventWithTouches:livingTouchAry];
-    [[UIApplication sharedApplication] sendEvent:event];
+//    UIEvent *event = [self eventWithTouches:livingTouchAry];
+    UIEvent *event = [[UIApplication sharedApplication] _touchesEvent];
+    [event kif_setEventWithTouches:livingTouchAry];
+    dispatch_sync(dispatch_get_main_queue(), ^{
+        [event _clearTouches];
+        for (UITouch *aTouch in livingTouchAry) {
+            [event _addTouch:aTouch forDelayedDelivery:NO];
+        }
+        [[UIApplication sharedApplication] sendEvent:event];
+    });
     if ((touch.phase==UITouchPhaseBegan)||touch.phase==UITouchPhaseMoved) {
         [touch setPhaseAndUpdateTimestamp:UITouchPhaseStationary];
     }

--- a/PlayTools/Controls/PTFakeTouch/addition/UIAccessibilityElement-KIFAdditions.m
+++ b/PlayTools/Controls/PTFakeTouch/addition/UIAccessibilityElement-KIFAdditions.m
@@ -141,9 +141,9 @@ MAKE_CATEGORIES_LOADABLE(UIAccessibilityElement_KIFAdditions)
         superview = superview.superview;
     }
     
-    if ([[UIApplication sharedApplication] isIgnoringInteractionEvents]) {
-        return nil;
-    }
+//    if ([[UIApplication sharedApplication] isIgnoringInteractionEvents]) {
+//        return nil;
+//    }
     
     // If we don't require tappability, at least make sure it's not hidden
     if ([view isHidden]) {

--- a/PlayTools/Controls/PTFakeTouch/addition/UIApplication-KIFAdditions.m
+++ b/PlayTools/Controls/PTFakeTouch/addition/UIApplication-KIFAdditions.m
@@ -104,10 +104,10 @@ static const void *KIFRunLoopModesKey = &KIFRunLoopModesKey;
 - (NSArray *)windowsWithKeyWindow
 {
     NSMutableArray *windows = self.windows.mutableCopy;
-    UIWindow *keyWindow = self.keyWindow;
-    if (![windows containsObject:keyWindow]) {
-        [windows addObject:keyWindow];
-    }
+//    UIWindow *keyWindow = self.keyWindow;
+//    if (![windows containsObject:keyWindow]) {
+//        [windows addObject:keyWindow];
+//    }
     return windows;
 }
 

--- a/PlayTools/Controls/PTFakeTouch/addition/UITouch-KIFAdditions.m
+++ b/PlayTools/Controls/PTFakeTouch/addition/UITouch-KIFAdditions.m
@@ -73,7 +73,7 @@ typedef struct {
 
 - (void)resetTouch{
     // Create a fake tap touch
-    UIWindow *window = [[UIApplication sharedApplication] keyWindow];
+    UIWindow *window = [[UIApplication sharedApplication].windows lastObject];
     CGPoint point = CGPointMake(0, 0);
     [self setWindow:window]; // Wipes out some values.  Needs to be first.
     
@@ -112,7 +112,7 @@ typedef struct {
     if (self == nil) {
         return nil;
     }
-    UIWindow *window = [UIApplication sharedApplication].keyWindow;
+    UIWindow *window = [[UIApplication sharedApplication].windows lastObject];
     CGPoint point = CGPointMake(0, 0);
     [self setWindow:window]; // Wipes out some values.  Needs to be first.
     

--- a/PlayTools/Controls/PTFakeTouch/addition/UIView-KIFAdditions.m
+++ b/PlayTools/Controls/PTFakeTouch/addition/UIView-KIFAdditions.m
@@ -397,19 +397,20 @@ NS_INLINE BOOL StringsMatchExceptLineBreaks(NSString *expected, NSString *actual
     // Web views don't handle touches in a normal fashion, but they do have a method we can call to tap them
     // This may not be necessary anymore. We didn't properly support controls that used gesture recognizers
     // when this was added, but we now do. It needs to be tested before we can get rid of it.
-    id /*UIWebBrowserView*/ webBrowserView = nil;
-    
-    if ([NSStringFromClass([self class]) isEqual:@"UIWebBrowserView"]) {
-        webBrowserView = self;
-    } else if ([self isKindOfClass:[UIWebView class]]) {
-        id webViewInternal = [self valueForKey:@"_internal"];
-        webBrowserView = [webViewInternal valueForKey:@"browserView"];
-    }
-    
-    if (webBrowserView) {
-        [webBrowserView tapInteractionWithLocation:point];
-        return;
-    }
+    // Xyct: indeed unnecessary. UIWebView already depracated.
+//    id /*UIWebBrowserView*/ webBrowserView = nil;
+//
+//    if ([NSStringFromClass([self class]) isEqual:@"UIWebBrowserView"]) {
+//        webBrowserView = self;
+//    } else if ([self isKindOfClass:[UIWebView class]]) {
+//        id webViewInternal = [self valueForKey:@"_internal"];
+//        webBrowserView = [webViewInternal valueForKey:@"browserView"];
+//    }
+//
+//    if (webBrowserView) {
+//        [webBrowserView tapInteractionWithLocation:point];
+//        return;
+//    }
     
     // Handle touches in the normal way for other views
     UITouch *touch = [[UITouch alloc] initAtPoint:point inView:self];

--- a/PlayTools/Controls/PlayAction.swift
+++ b/PlayTools/Controls/PlayAction.swift
@@ -64,18 +64,20 @@ class JoystickAction: Action {
         self.shift = shift / 2
         self.id = id
         if let keyboard = GCKeyboard.coalesced?.keyboardInput {
-            keyboard.button(forKeyCode: keys[0])?.pressedChangedHandler = { _, _, _ in
-                self.update()
+            for key in keys {
+                keyboard.button(forKeyCode: key)?.pressedChangedHandler = { _, _, _ in
+                    Toucher.touchQueue.async(execute: self.update)
+                }
             }
-            keyboard.button(forKeyCode: keys[1])?.pressedChangedHandler = { _, _, _ in
-                self.update()
-            }
-            keyboard.button(forKeyCode: keys[2])?.pressedChangedHandler = { _, _, _ in
-                self.update()
-            }
-            keyboard.button(forKeyCode: keys[3])?.pressedChangedHandler = { _, _, _ in
-                self.update()
-            }
+//            keyboard.button(forKeyCode: keys[1])?.pressedChangedHandler = { _, _, _ in
+//                self.update()
+//            }
+//            keyboard.button(forKeyCode: keys[2])?.pressedChangedHandler = { _, _, _ in
+//                self.update()
+//            }
+//            keyboard.button(forKeyCode: keys[3])?.pressedChangedHandler = { _, _, _ in
+//                self.update()
+//            }
         }
     }
 
@@ -111,7 +113,7 @@ class JoystickAction: Action {
                     start.y += (touch.y - start.y) / 8
                     moving = true
                     Toucher.touchcam(point: start, phase: UITouch.Phase.began, tid: id)
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.04) {
+                    Toucher.touchQueue.asyncAfter(deadline: .now() + 0.04) {
                         if self.moving {
                             Toucher.touchcam(point: touch, phase: UITouch.Phase.moved, tid: self.id)
                         }

--- a/PlayTools/Controls/PlayMice.swift
+++ b/PlayTools/Controls/PlayMice.swift
@@ -48,8 +48,10 @@ typealias ResponseBlockBool = @convention(block) (_ event: Any) -> Bool
         camera = CameraControl(centerX: key[0].absoluteX, centerY: key[1].absoluteY)
         for mouse in GCMouse.mice() {
             mouse.mouseInput?.mouseMovedHandler = { _, deltaX, deltaY in
-                if !mode.visible {
-                    self.camera?.updated(CGFloat(deltaX), CGFloat(deltaY))
+                Toucher.touchQueue.async {
+                    if !mode.visible {
+                        self.camera?.updated(CGFloat(deltaX), CGFloat(deltaY))
+                    }
                 }
             }
         }
@@ -123,7 +125,7 @@ final class CameraControl {
 
     func delay(_ delay: Double, closure: @escaping () -> Void) {
         let when = DispatchTime.now() + delay
-        DispatchQueue.main.asyncAfter(deadline: when, execute: closure)
+        Toucher.touchQueue.asyncAfter(deadline: when, execute: closure)
     }
 
     // if max speed of this touch is high

--- a/PlayTools/Controls/Toucher.swift
+++ b/PlayTools/Controls/Toucher.swift
@@ -7,9 +7,19 @@ import Foundation
 import UIKit
 
 class Toucher {
+
+    static var keyWindow: UIWindow?
+
     static func touchcam(point: CGPoint, phase: UITouch.Phase, tid: Int) {
+        if keyWindow == nil {
+            keyWindow = UIApplication
+                .shared
+                .connectedScenes
+                .flatMap { ($0 as? UIWindowScene)?.windows ?? [] }
+                .first { $0.isKeyWindow }
+        }
         DispatchQueue.main.async {
-            PTFakeMetaTouch.fakeTouchId(tid, at: point, with: phase)
+            PTFakeMetaTouch.fakeTouchId(tid, at: point, with: phase, in: keyWindow)
         }
     }
 }

--- a/PlayTools/Controls/Toucher.swift
+++ b/PlayTools/Controls/Toucher.swift
@@ -9,16 +9,17 @@ import UIKit
 class Toucher {
 
     static var keyWindow: UIWindow?
+    static var touchQueue = DispatchQueue.init(label: "playcover.toucher", qos: .userInteractive)
 
     static func touchcam(point: CGPoint, phase: UITouch.Phase, tid: Int) {
-        if keyWindow == nil {
-            keyWindow = UIApplication
-                .shared
-                .connectedScenes
-                .flatMap { ($0 as? UIWindowScene)?.windows ?? [] }
-                .first { $0.isKeyWindow }
-        }
-        DispatchQueue.main.async {
+        touchQueue.async {
+            if keyWindow == nil {
+                keyWindow = UIApplication
+                    .shared
+                    .connectedScenes
+                    .flatMap { ($0 as? UIWindowScene)?.windows ?? [] }
+                    .first { $0.isKeyWindow }
+            }
             PTFakeMetaTouch.fakeTouchId(tid, at: point, with: phase, in: keyWindow)
         }
     }


### PR DESCRIPTION
Depends on #18 
Attempts to fix https://github.com/PlayCover/PlayCover/issues/116

Tests show that doing too much work on the main thread makes the touch events lag and lose. As the code beyond `Toucher` is already simple enough, it is decided to optimize the underlying library.
## Eliminate redundant calculations

PTFakeTouch is the underlying library that playtools use to send touch events. However, this library was initially only a proof of concept and not optimized. Specifically, for every touch event, it sends 100 touch points at once, while in practice usually only 2~4 points are pressed at the same time and needs to be sent at once. 

To make things worse, the `kif_setEventWithTouches()` function at `UIEvent+KifAdditions.m:55` , which is called by `eventWithTouches()` at `PTFakeMetaTouch.m:121`, would do lots of work on each touch point in the event (time complexity up to quadratic towards size of the touch point array), taking up lots or resources. 

Therefore, I make a new array to store only the active touch points, and pass only them to the function mentiond above and the event system, so as to make the library several times faster hopefully.

This PR is based on previous PR of eliminating depracation warnings, so as to avoid merge conflict.

This may or may not solve the problem. Cause I'm not encountering the issue mentioned above right now, I cannot test it. Anybody encountering the issue and is willing to test is welcome.
## Move routines out of main thread

Currently all fake touch routines run on the main thread. Although this thread has the highest priority, it is also where the UI updates happen. As games are already tight on the main thread resource, adding more jobs to it can easily make it overload.

Keeping in mind that our processor has multiple cores, jobs running in different threads can effectively utilize the core resources to accelarate execution. Another modification this PR does is to create a new serial high priority dispatch queue, and execute all fake touch jobs there.

In testing, simply doing so could cause crash. After investigation, it is believed that invocations of private methods of `UIEvent` could sometimes leave it in an illegal state. To workaround this, those code are syncronised with main thread, so that no other main thread jobs can be run before the state ot `UIEvent` is back to legal.

Current code also inserts a `IOHIDEvent` object into `UIEvent`. But this object is only accessible internally, not accessible by games. Plus, creating such an object is time-consuming, and test shows that not inserting such an object does not make any difference. Apple's document says `UIEvent` object is constructed from `IOHIDEvent`, the latter is just a lower level representation of touch events. So this PR no longer inserts `IOHIDEvent` object.