### PR TITLE
fix: Add missing setting data to fix wrong behavior

### DIFF
--- a/PlayTools/Controls/ControlMode.swift
+++ b/PlayTools/Controls/ControlMode.swift
@@ -10,7 +10,7 @@ let mode = ControlMode.mode
 @objc final public class ControlMode: NSObject {
 
     @objc static public let mode = ControlMode()
-    @objc public var visible: Bool = PlaySettings.shared.gamingMode
+    @objc public var visible: Bool = PlaySettings.shared.mouseMapping
 
     @objc static public func isMouseClick(_ event: Any) -> Bool {
         return [1, 2].contains(Dynamic(event).type.asInt)
@@ -23,7 +23,7 @@ let mode = ControlMode.mode
                     if screen.fullscreen {
                         screen.switchDock(true)
                     }
-                    if PlaySettings.shared.gamingMode {
+                    if PlaySettings.shared.mouseMapping {
                         Dynamic.NSCursor.unhide()
 						disableCursor(1)
                     }
@@ -31,7 +31,7 @@ let mode = ControlMode.mode
                 }
             } else {
                 if visible {
-                    if PlaySettings.shared.gamingMode {
+                    if PlaySettings.shared.mouseMapping {
                         Dynamic.NSCursor.hide()
                         disableCursor(0)
                     }

--- a/PlayTools/Controls/PlayAction.swift
+++ b/PlayTools/Controls/PlayAction.swift
@@ -69,7 +69,7 @@ class DraggableButtonAction: ButtonAction {
     override init(id: Int, keyid: Int, key: GCKeyCode, point: CGPoint) {
         self.releasePoint = point
         super.init(id: id, keyid: keyid, key: key, point: point)
-        if settings.gamingMode {
+        if settings.mouseMapping {
             PlayMice.shared.setupMouseMovedHandler()
         }
     }

--- a/PlayTools/Controls/PlayInput.swift
+++ b/PlayTools/Controls/PlayInput.swift
@@ -31,7 +31,7 @@ final class PlayInput: NSObject {
                 counter += 1
         }
 
-        if settings.gamingMode {
+        if settings.isGame && settings.mouseMapping {
             for mouse in keymap.keymapData.mouseAreaModel {
                 PlayMice.shared.setup(mouse)
                 counter += 1
@@ -93,7 +93,7 @@ final class PlayInput: NSObject {
     ]
 
     private func swapMode(_ pressed: Bool) {
-        if !PlaySettings.shared.gamingMode {
+        if !(settings.isGame && settings.mouseMapping) {
             return
         }
         if pressed {

--- a/PlayTools/Controls/PlayInput.swift
+++ b/PlayTools/Controls/PlayInput.swift
@@ -31,7 +31,7 @@ final class PlayInput: NSObject {
                 counter += 1
         }
 
-        if settings.isGame && settings.mouseMapping {
+        if settings.mouseMapping {
             for mouse in keymap.keymapData.mouseAreaModel {
                 PlayMice.shared.setup(mouse)
                 counter += 1
@@ -93,7 +93,7 @@ final class PlayInput: NSObject {
     ]
 
     private func swapMode(_ pressed: Bool) {
-        if !(settings.isGame && settings.mouseMapping) {
+        if !settings.mouseMapping {
             return
         }
         if pressed {

--- a/PlayTools/Controls/PlayMice.swift
+++ b/PlayTools/Controls/PlayMice.swift
@@ -20,7 +20,7 @@ typealias ResponseBlockBool = @convention(block) (_ event: Any) -> Bool
 
     private static var isInit = false
 
-    private var acceptMouseEvents = !PlaySettings.shared.gamingMode
+    private var acceptMouseEvents = !PlaySettings.shared.mouseMapping
 
     public override init() {
         super.init()

--- a/PlayTools/PlaySettings.swift
+++ b/PlayTools/PlaySettings.swift
@@ -41,7 +41,7 @@ let settings = PlaySettings.shared
 
     lazy var keymapping = settingsData.keymapping
 
-    lazy var gamingMode: Bool = isGame
+    lazy var mouseMapping = settingsData.mouseMapping
 
     lazy var notch = settingsData.notch
 
@@ -51,7 +51,7 @@ let settings = PlaySettings.shared
 
     lazy var windowSizeWidth = CGFloat(settingsData.windowWidth)
 
-    @objc lazy var adaptiveDisplay = isGame
+    @objc lazy var adaptiveDisplay = settingsData.resolution == 0 ? false : true
 
     @objc lazy var deviceModel = settingsData.iosDeviceModel as NSString
 
@@ -82,7 +82,7 @@ struct AppSettingsData: Codable {
     var refreshRate = 60
     var windowWidth = 1920
     var windowHeight = 1080
-    var resolution = 2
+    var resolution = 0
     var aspectRatio = 1
     var notch = false
     var bypass = false

--- a/PlayTools/PlaySettings.swift
+++ b/PlayTools/PlaySettings.swift
@@ -7,8 +7,6 @@ let settings = PlaySettings.shared
 @objc public final class PlaySettings: NSObject {
     @objc public static let shared = PlaySettings()
 
-    private static let keywords = ["game", "unity", "metal", "netflix", "opengl", "minecraft", "mihoyo", "disney"]
-
     let bundleIdentifier = Bundle.main.infoDictionary?["CFBundleIdentifier"] as? String ?? ""
     let settingsUrl: URL
     var settingsData: AppSettingsData
@@ -25,17 +23,6 @@ let settings = PlaySettings.shared
             os_log("[PlayTools] PlaySettings decode failed.\n%@", type: .error, error as CVarArg)
         }
     }
-
-    var isGame: Bool = {
-        if let info = Bundle.main.infoDictionary?.description {
-            for keyword in PlaySettings.keywords {
-                if info.contains(keyword) && !info.contains("xbox") {
-                    return true
-                }
-            }
-        }
-        return false
-    }()
 
     lazy var discordActivity = settingsData.discordActivity
 
@@ -82,7 +69,7 @@ struct AppSettingsData: Codable {
     var refreshRate = 60
     var windowWidth = 1920
     var windowHeight = 1080
-    var resolution = 0
+    var resolution = 2
     var aspectRatio = 1
     var notch = false
     var bypass = false


### PR DESCRIPTION
Btw I have question.
Q: Does adaptive resolution should work only with games? If not we should make resolution's default value 0 for non-game app.

ps. I think mouse mapping and sensitivity settings in PlayCover's AppSettingView should disabled when key mapping is unchecked because mouse mapping is working only when key mapping is enabled.