### PR TITLE
Feat: button-controlled mouse drag action

### DIFF
--- a/PlayTools/Controls/PlayAction.swift
+++ b/PlayTools/Controls/PlayAction.swift
@@ -51,6 +51,41 @@ class ButtonAction: Action {
     }
 }
 
+class DraggableButtonAction: ButtonAction {
+    static public var activeButton: DraggableButtonAction?
+
+    var releasePoint: CGPoint
+
+    override init(id: Int, keyid: Int, key: GCKeyCode, point: CGPoint) {
+        self.releasePoint = point
+        super.init(id: id, keyid: keyid, key: key, point: point)
+        PlayMice.shared.setupMouseMovedHandler()
+    }
+
+    override func update(pressed: Bool) {
+        if pressed {
+            Toucher.touchcam(point: point, phase: UITouch.Phase.began, tid: id)
+            self.releasePoint = point
+            DraggableButtonAction.activeButton = self
+        } else {
+            DraggableButtonAction.activeButton = nil
+            Toucher.touchcam(point: releasePoint, phase: UITouch.Phase.ended, tid: id)
+        }
+    }
+
+    override func invalidate() {
+        DraggableButtonAction.activeButton = nil
+        PlayMice.shared.stop()
+        super.invalidate()
+    }
+
+    func onMouseMoved(deltaX: CGFloat, deltaY: CGFloat) {
+        self.releasePoint.x += deltaX * CGFloat(PlaySettings.shared.sensivity)
+        self.releasePoint.y -= deltaY * CGFloat(PlaySettings.shared.sensivity)
+        Toucher.touchcam(point: self.releasePoint, phase: UITouch.Phase.moved, tid: id)
+    }
+}
+
 class JoystickAction: Action {
     let keys: [GCKeyCode]
     let center: CGPoint

--- a/PlayTools/Controls/PlayInput.swift
+++ b/PlayTools/Controls/PlayInput.swift
@@ -27,6 +27,12 @@ final class PlayInput: NSObject {
                                             key: GCKeyCode.init(rawValue: CFIndex(key[0])),
                                             point: CGPoint(x: key[1].absoluteX,
                                                            y: key[2].absoluteY)))
+            } else if key.count == 5 {
+                actions.append(DraggableButtonAction(id: counter,
+                                                     keyid: Int(key[0]),
+                                                     key: GCKeyCode.init(rawValue: CFIndex(key[0])),
+                                                     point: CGPoint(x: key[1].absoluteX,
+                                                                    y: key[2].absoluteY)))
             } else if key.count == 8 {
                 actions.append(JoystickAction(id: counter,
                                               keys: [GCKeyCode.init(rawValue: CFIndex(key[0])),

--- a/PlayTools/Controls/PlayMice.swift
+++ b/PlayTools/Controls/PlayMice.swift
@@ -46,10 +46,18 @@ typealias ResponseBlockBool = @convention(block) (_ event: Any) -> Bool
 
     public func setup(_ key: [CGFloat]) {
         camera = CameraControl(centerX: key[0].absoluteX, centerY: key[1].absoluteY)
+        setupMouseMovedHandler()
+    }
+
+    public func setupMouseMovedHandler() {
         for mouse in GCMouse.mice() {
             mouse.mouseInput?.mouseMovedHandler = { _, deltaX, deltaY in
                 if !mode.visible {
-                    self.camera?.updated(CGFloat(deltaX), CGFloat(deltaY))
+                    if let draggableButton = DraggableButtonAction.activeButton {
+                        draggableButton.onMouseMoved(deltaX: CGFloat(deltaX), deltaY: CGFloat(deltaY))
+                    } else {
+                        self.camera?.updated(CGFloat(deltaX), CGFloat(deltaY))
+                    }
                 }
             }
         }

--- a/PlayTools/Keymap/EditorController.swift
+++ b/PlayTools/Keymap/EditorController.swift
@@ -152,6 +152,15 @@ final class EditorController: NSObject {
         }
     }
 
+    @objc public func addDraggableButton(_ center: CGPoint, _ keyCode: Int) {
+        if editorMode {
+            addControlToView(control: DraggableButtonModel(data: ControlData(keyCodes: [keyCode],
+                                                                       size: 15,
+                                                                       xCoord: center.x,
+                                                                       yCoord: center.y)))
+        }
+    }
+
     func updateEditorText(_ str: String) {
         view.label?.text = str
     }


### PR DESCRIPTION
Some mobile games require the operation that the player press on some button and drag it to somewhere else, then release it to complete some action. In fact Genshin has this operation too. We just happen to work around this by a button press and a separate camera control. But this is not a natural human operation and may not work in other games.
![截屏2022-08-30 13 25 45](https://user-images.githubusercontent.com/16048758/187356630-e7b54221-d965-4781-8bd4-830340ee5fd0.png)

The following video demonstrates how a draggable button can be used in a MOBA game. (it's the exact video I sent in the Discord server)
https://cdn.discordapp.com/attachments/996713647827066981/1013902534584320000/draggableButton.mp4

## How to add a draggable button
1. Create a mouse drag area
2. While focused on the mouse drag area, press any key on the keyboard
## How to use a draggable button
1. Press and hold the mapped key for the draggable button
2. Move mouse to move it's touch point
3. Release mapped key to end the touch at the moved point
## Note
This can work with or without a mouse drag area present. With it present, when the draggable button is pressed, mouse movement is mapped to the button only. Without it present, mouse movement has no effect if no draggable button pressed.

I'm not sure whether the circle menu can hold more than six items or not. Plus, I don't know how to find an approriate icon for it. That's why this action is not added to circle menu.