### PR TITLE
Fix: editor UI not shown in some games

### DIFF
--- a/PlayTools/Controls/MenuController.swift
+++ b/PlayTools/Controls/MenuController.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-extension UIViewController {
+extension UIWindow {
     @objc
     func switchEditorMode(_ sender: AnyObject) {
         EditorController.shared.switchMode()
@@ -37,10 +37,10 @@ var keymapping = ["Open/Close Keymapping Editor",
                   "Delete selected element",
                   "Upsize selected element",
                   "Downsize selected element"]
-var keymappingSelectors = [#selector(UIViewController.switchEditorMode(_:)),
-                           #selector(UIViewController.removeElement(_:)),
-                           #selector(UIViewController.upscaleElement(_:)),
-                           #selector(UIViewController.downscaleElement(_:))]
+var keymappingSelectors = [#selector(UIWindow.switchEditorMode(_:)),
+                           #selector(UIWindow.removeElement(_:)),
+                           #selector(UIWindow.upscaleElement(_:)),
+                           #selector(UIWindow.downscaleElement(_:))]
 
 class MenuController {
     init(with builder: UIMenuBuilder) {

--- a/PlayTools/Controls/Toucher.swift
+++ b/PlayTools/Controls/Toucher.swift
@@ -14,11 +14,7 @@ class Toucher {
     static func touchcam(point: CGPoint, phase: UITouch.Phase, tid: Int) {
         touchQueue.async {
             if keyWindow == nil {
-                keyWindow = UIApplication
-                    .shared
-                    .connectedScenes
-                    .flatMap { ($0 as? UIWindowScene)?.windows ?? [] }
-                    .first { $0.isKeyWindow }
+                keyWindow = screen.keyWindow
             }
             PTFakeMetaTouch.fakeTouchId(tid, at: point, with: phase, in: keyWindow)
         }

--- a/PlayTools/Keymap/DragElementsView.swift
+++ b/PlayTools/Keymap/DragElementsView.swift
@@ -27,7 +27,7 @@ class KeymapHolder: CircleMenuDelegate {
         menu?.center = location
         menu?.backgroundColor = UIColor.gray
         menu?.layer.cornerRadius = menu!.frame.size.width / 2
-        screen.window?.addSubview(menu!)
+        screen.keyWindow?.addSubview(menu!)
         menu?.backgroundColor = UIColor.black
         menu?.onTap()
     }

--- a/PlayTools/Keymap/EditorController.swift
+++ b/PlayTools/Keymap/EditorController.swift
@@ -20,7 +20,7 @@ final class EditorController: NSObject {
     lazy var editorWindow: UIWindow = initWindow()
     var previousWindow: UIWindow?
     var controls: [ControlModel] = []
-    var viewController = EditorViewController(nibName: nil, bundle: nil)
+    lazy var viewController = EditorViewController(nibName: nil, bundle: nil)
     lazy var view: EditorView! = viewController.view as? EditorView
 
     private func initWindow() -> UIWindow {

--- a/PlayTools/Keymap/EditorController.swift
+++ b/PlayTools/Keymap/EditorController.swift
@@ -3,6 +3,12 @@ import SwiftUI
 
 let editor = EditorController.shared
 
+class EditorViewController: UIViewController {
+    override func loadView() {
+        view = EditorView()
+    }
+}
+
 final class EditorController: NSObject {
 
     static let shared = EditorController()
@@ -11,8 +17,17 @@ final class EditorController: NSObject {
 
     var focusedControl: ControlModel?
 
+    lazy var editorWindow: UIWindow = initWindow()
+    var previousWindow: UIWindow?
     var controls: [ControlModel] = []
-    lazy var view: EditorView = EditorView()
+    var viewController = EditorViewController(nibName: nil, bundle: nil)
+    lazy var view: EditorView! = viewController.view as? EditorView
+
+    private func initWindow() -> UIWindow {
+        let window = UIWindow(windowScene: screen.windowScene!)
+        window.rootViewController = viewController
+        return window
+    }
 
     private func addControlToView(control: ControlModel) {
         controls.append(control)
@@ -35,32 +50,31 @@ final class EditorController: NSObject {
 
     public func switchMode() {
         lock.lock()
-        if EditorController.shared.editorMode {
-            Toast.showOver(msg: "Keymapping saved")
-        } else {
-            Toast.showOver(msg: "Click to start keymmaping edit")
-        }
 
         if editorMode {
             KeymapHolder.shared.hide()
             saveButtons()
-            view.removeFromSuperview()
             editorMode = false
+            editorWindow.windowScene = nil
+            previousWindow?.makeKeyAndVisible()
             mode.show(false)
             focusedControl = nil
+            Toast.showOver(msg: "Keymapping saved")
         } else {
             mode.show(true)
+            previousWindow = screen.keyWindow
+            editorWindow.windowScene = screen.windowScene
             editorMode = true
+            editorWindow.makeKeyAndVisible()
             showButtons()
-            screen.window?.addSubview(view)
-            view.becomeFirstResponder()
+            Toast.showOver(msg: "Click to start keymmaping edit")
         }
         lock.unlock()
     }
 
     var editorMode: Bool {
-        get { view.isUserInteractionEnabled }
-        set { view.isUserInteractionEnabled = newValue}
+        get { !editorWindow.isHidden }
+        set { editorWindow.isHidden = !newValue}
     }
 
     public func setKeyCode(_ key: Int) {
@@ -174,7 +188,6 @@ extension UIResponder {
 
 class EditorView: UIView {
     override var preferredFocusEnvironments: [UIFocusEnvironment] {
-        if !isUserInteractionEnabled { return [self] }
         if let btn = editor.focusedControl?.button {
             return [btn]
         }
@@ -192,7 +205,7 @@ class EditorView: UIView {
     init() {
         super.init(frame: .zero)
         self.frame = screen.screenRect
-        self.isUserInteractionEnabled = false
+        self.isUserInteractionEnabled = true
         let single = UITapGestureRecognizer(target: self, action: #selector(self.doubleClick(sender:)))
         single.numberOfTapsRequired = 1
         self.addGestureRecognizer(single)
@@ -208,7 +221,6 @@ class EditorView: UIView {
     var label: UILabel?
 
     @objc func pressed(sender: UIButton!) {
-        if !isUserInteractionEnabled { return }
         if let button = sender as? Element {
             if editor.focusedControl?.button == nil || editor.focusedControl?.button != button {
                 editor.updateFocus(button: sender)
@@ -217,7 +229,6 @@ class EditorView: UIView {
     }
 
     @objc func dragged(_ sender: UIPanGestureRecognizer) {
-        if !isUserInteractionEnabled { return }
         if let ele = sender.view as? Element {
             if editor.focusedControl?.button == nil || editor.focusedControl?.button != ele {
                 editor.updateFocus(button: ele)

--- a/PlayTools/Keymap/EditorController.swift
+++ b/PlayTools/Keymap/EditorController.swift
@@ -55,7 +55,7 @@ final class EditorController: NSObject {
             KeymapHolder.shared.hide()
             saveButtons()
             editorMode = false
-            editorWindow.windowScene = nil
+//            editorWindow.windowScene = nil
             previousWindow?.makeKeyAndVisible()
             mode.show(false)
             focusedControl = nil
@@ -63,7 +63,7 @@ final class EditorController: NSObject {
         } else {
             mode.show(true)
             previousWindow = screen.keyWindow
-            editorWindow.windowScene = screen.windowScene
+//            editorWindow.windowScene = screen.windowScene
             editorMode = true
             editorWindow.makeKeyAndVisible()
             showButtons()

--- a/PlayTools/PlayScreen.swift
+++ b/PlayTools/PlayScreen.swift
@@ -111,6 +111,18 @@ public final class PlayScreen: NSObject {
         max / 100.0
     }
 
+    var keyWindow: UIWindow? {
+        return UIApplication
+            .shared
+            .connectedScenes
+            .flatMap { ($0 as? UIWindowScene)?.windows ?? [] }
+            .first { $0.isKeyWindow }
+    }
+
+    var windowScene: UIWindowScene? {
+        window?.windowScene
+    }
+
     var window: UIWindow? {
         return UIApplication.shared.windows.first
     }

--- a/PlayTools/Utils/Toast.swift
+++ b/PlayTools/Utils/Toast.swift
@@ -8,14 +8,14 @@ import UIKit
 
 class Toast {
     public static func showOver(msg: String) {
-        if let controller =  PlayInput.shared.root {
-            Toast.show(message: msg, controller: controller)
+        if let parent = screen.keyWindow {
+            Toast.show(message: msg, parent: parent)
         }
     }
 
     // swiftlint:disable function_body_length
 
-    private static func show(message: String, controller: UIViewController) {
+    private static func show(message: String, parent: UIView) {
         let toastContainer = UIView(frame: CGRect())
         toastContainer.backgroundColor = UIColor.black.withAlphaComponent(0.6)
         toastContainer.alpha = 0.0
@@ -32,7 +32,7 @@ class Toast {
         toastLabel.numberOfLines = 0
 
         toastContainer.addSubview(toastLabel)
-        controller.view.addSubview(toastContainer)
+        parent.addSubview(toastContainer)
 
         toastLabel.translatesAutoresizingMaskIntoConstraints = false
         toastContainer.translatesAutoresizingMaskIntoConstraints = false
@@ -70,25 +70,25 @@ class Toast {
         let controllerConstraint1 = NSLayoutConstraint(item: toastContainer,
                                                        attribute: .leading,
                                                        relatedBy: .equal,
-                                                       toItem: controller.view,
+                                                       toItem: parent,
                                                        attribute: .leading,
                                                        multiplier: 1,
                                                        constant: 65)
         let controllerConstraint2 = NSLayoutConstraint(item: toastContainer,
                                                        attribute: .trailing,
                                                        relatedBy: .equal,
-                                                       toItem: controller.view,
+                                                       toItem: parent,
                                                        attribute: .trailing,
                                                        multiplier: 1,
                                                        constant: -65)
         let controllerConstraint3 = NSLayoutConstraint(item: toastContainer,
                                                        attribute: .bottom,
                                                        relatedBy: .equal,
-                                                       toItem: controller.view,
+                                                       toItem: parent,
                                                        attribute: .bottom,
                                                        multiplier: 1,
                                                        constant: -75)
-        controller.view.addConstraints([controllerConstraint1, controllerConstraint2, controllerConstraint3])
+        parent.addConstraints([controllerConstraint1, controllerConstraint2, controllerConstraint3])
 
         UIView.animate(withDuration: 0.5, delay: 0.0, options: .curveEaseIn, animations: {
             toastContainer.alpha = 1.0


### PR DESCRIPTION
Should fix https://github.com/PlayCover/PlayCover/issues/64

In some games, when opening the keymapping editor, the editor does not show, nor does the toast. But the switching does succeed, since cursor is hidden when editor is closed. The reason may be that the game is displaying it's content in a different UIWindow from where the editor and toast shows. 

Before this PR, code assumes there is only one UIWindow, and takes the first UIWindow object from the UIWindow array of this application as the only UIWindow. 

In this PR, the editor UI is moved to a new UIWindow. When editor is shown, this UIWindow is made visible. Otherwise, this UIWindow is made hidden. Although UIWindow can directly have subviews, doing so without a UIViewController prevents the UIWindow from setting it's orientation to landscape. Therefore, I have to add a UIViewController between editor view and the UIWindow.

Before this PR, toast is displayed from the root view controller of the application's UIWindow. In this PR, toast would find the current key window to display on, regardless of any view controller of that window.

Since I can't find an IPA file of _Girls' Frontline_, I have not tested on it. But I tested on another game _Sky: Children of the Light_, which has the same symptom as shown in the issue. 

An alternative solution to this issue is to display editor the same way as toast is displayed, which is to find the current key window and add subviews to that window. However, this cannot gurantee that the editor is always the top UIView during the editing process. The game may further add more subviews to that UIWindow, covering the editor UI.

For fun: How to trigger rotation with fancy animation in Genshin?
Set resolution width and height equal -> Open Paimon menu -> Click "feedback" -> Open then close editor -> Quit "feedback" page -> Open editor
Yes this is a bug, but not introduced by me. There is already an issue for that. I just add more fun to that issue :)