### PR TITLE
Fix: multi-touch with mouse when mouse mapping is off

### DIFF
--- a/PlayTools/Controls/PlayMice.swift
+++ b/PlayTools/Controls/PlayMice.swift
@@ -112,20 +112,21 @@ typealias ResponseBlockBool = @convention(block) (_ event: Any) -> Bool
     private func setupMouseButton(_up: Int, _down: Int) {
         // no this is not up, this is down. And the later down is up.
         Dynamic.NSEvent.addLocalMonitorForEventsMatchingMask(_up, handler: { event in
-            if !mode.visible || self.acceptMouseEvents {
-                self.mouseActions[_up]?.update(pressed: true)
-                if self.acceptMouseEvents {
-                    let window = Dynamic(event, memberName: "window").asObject
-                    if !self.fakedMousePressed
-                        // for traffic light buttons when not fullscreen
-                        && self.cursorPos.y > 0
-                        // for traffic light buttons when fullscreen
-                        && window == screen.nsWindow {
-                        Toucher.touchcam(point: self.cursorPos, phase: UITouch.Phase.began, tid: 1)
-                        self.fakedMousePressed = true
-                        return nil
-                    }
+            if self.acceptMouseEvents {
+                let window = Dynamic(event, memberName: "window").asObject
+                if !self.fakedMousePressed
+                    // for traffic light buttons when not fullscreen
+                    && self.cursorPos.y > 0
+                    // for traffic light buttons when fullscreen
+                    && window == screen.nsWindow {
+                    Toucher.touchcam(point: self.cursorPos, phase: UITouch.Phase.began, tid: 1)
+                    self.fakedMousePressed = true
+                    return nil
                 }
+                return event
+            }
+            if !mode.visible {
+                self.mouseActions[_up]?.update(pressed: true)
                 return nil
             } else if EditorController.shared.editorMode {
                 if _up == 8 {
@@ -138,15 +139,15 @@ typealias ResponseBlockBool = @convention(block) (_ event: Any) -> Bool
             return event
         } as ResponseBlock)
         Dynamic.NSEvent.addLocalMonitorForEventsMatchingMask(_down, handler: { event in
-            if !mode.visible || self.acceptMouseEvents {
-                self.mouseActions[_up]?.update(pressed: false)
-                if self.acceptMouseEvents {
-                    if self.fakedMousePressed {
-                        self.fakedMousePressed = false
-                        Toucher.touchcam(point: self.cursorPos, phase: UITouch.Phase.ended, tid: 1)
-                        return nil
-                    }
+            if self.acceptMouseEvents {
+                if self.fakedMousePressed {
+                    self.fakedMousePressed = false
+                    Toucher.touchcam(point: self.cursorPos, phase: UITouch.Phase.ended, tid: 1)
+                    return nil
                 }
+            }
+            if !mode.visible {
+                self.mouseActions[_up]?.update(pressed: false)
                 return nil
             }
             return event

--- a/PlayTools/PlayScreen.swift
+++ b/PlayTools/PlayScreen.swift
@@ -88,7 +88,7 @@ public final class PlayScreen: NSObject {
         return size.toAspectRatio()
     }
     var fullscreen: Bool {
-        return Dynamic(nsWindow).styleMask.contains(16384).asBool ?? false
+        return (Dynamic(nsWindow).styleMask.asInt ?? 0) & 16384 != 0
     }
 
     @objc public var screenRect: CGRect {


### PR DESCRIPTION
Fixes https://github.com/PlayCover/PlayCover/issues/278

Playtools' way of faking touches handles multi-touch states in its own code. As a result, mouse input when mouse mapping is off, which does not go through fake touch, has no multi-touch ability with faked touches. 

This fix is done by identifying mouse click and move events in event handlers, stopping the events from propagating to UIApplication, instead making fake touch handles them. In this way fake touch has multi-touch info of mouse input, thus supporting multi-touch with mouse input.

There is some math in converting NSWindow coordinates to UIWindow coordinates. But it would be straight forward if you look at the code.

I was thinking about doing so by sending hardware touch events instead of directly handle UIEvent object, but it turns out that hardware events cannot automatically handle multi-touch either. But I have come out of another idea of improving fake touch performance, and a way to test it, which I may try to implement in the next days.