### PR TITLE
Dramatically improve fake touch efficiency

### DIFF
--- a/PlayTools/Controls/PTFakeTouch/PTFakeMetaTouch.h
+++ b/PlayTools/Controls/PTFakeTouch/PTFakeMetaTouch.h
@@ -31,10 +31,10 @@ double ColourDistance(RGB e1, RGB e2);
  *  @param phase   操作的类别 type of the operation
  *  @param window  key window in which touch event is to happen
  *
- *  @return realid returns the allocated ID for this touch point, or -1 if no such point
+ *  @return deleted whether the system had deleted a previous touch
  */
 
-+ (NSInteger)fakeTouchId:(NSInteger)pointId AtPoint:(CGPoint)point withTouchPhase:(UITouchPhase)phase inWindow:(UIWindow*)window;
++ (NSInteger)fakeTouchId:(NSInteger)pointId AtPoint:(CGPoint)point withTouchPhase:(UITouchPhase)phase inWindow:(UIWindow*)window onView:(UIView*)view;
 /**
  *  Get a not used pointId 获取一个没有使用过的触屏序列号 obtain a never used touch screen sequence number
  *

--- a/PlayTools/Controls/PTFakeTouch/PTFakeMetaTouch.m
+++ b/PlayTools/Controls/PTFakeTouch/PTFakeMetaTouch.m
@@ -12,7 +12,7 @@
 #import "UIEvent+KIFAdditions.h"
 #import "CoreFoundation/CFRunLoop.h"
 #include <dlfcn.h>
-#include <stdlib.h>
+#include <string.h>
 
 static NSMutableArray *touchAry;
 static NSMutableArray *livingTouchAry;

--- a/PlayTools/Controls/PTFakeTouch/PTFakeMetaTouch.m
+++ b/PlayTools/Controls/PTFakeTouch/PTFakeMetaTouch.m
@@ -10,10 +10,17 @@
 #import "UITouch-KIFAdditions.h"
 #import "UIApplication-KIFAdditions.h"
 #import "UIEvent+KIFAdditions.h"
+#import "CoreFoundation/CFRunLoop.h"
 #include <dlfcn.h>
+#include <stdlib.h>
 
 static NSMutableArray *touchAry;
 static NSMutableArray *livingTouchAry;
+static CFRunLoopSourceRef source;
+
+static UITouch* toRemove = NULL, *toStationarify = NULL;
+
+NSArray *safeTouchAry;
 
 void disableCursor(boolean_t disable){
        void *handle;
@@ -59,6 +66,29 @@ void moveCursorTo(CGPoint point){
        }
 }
 
+void eventSendCallback(void* info) {
+    UIEvent *event = [[UIApplication sharedApplication] _touchesEvent];
+    // to retain objects from being released
+    [event _clearTouches];
+    NSArray *myAry = safeTouchAry;
+    for (UITouch *aTouch in myAry) {
+        switch (aTouch.phase) {
+            case UITouchPhaseEnded:
+            case UITouchPhaseCancelled:
+                toRemove = aTouch;
+                break;
+            case UITouchPhaseBegan:
+//            case UITouchPhaseMoved:
+                toStationarify = aTouch;
+                break;
+            default:
+                break;
+        }
+        [event _addTouch:aTouch forDelayedDelivery:NO];
+    }
+    [[UIApplication sharedApplication] sendEvent:event];
+}
+
 @implementation PTFakeMetaTouch
 
 + (void)load{
@@ -71,6 +101,15 @@ void moveCursorTo(CGPoint point){
         [touch setPhaseAndUpdateTimestamp:UITouchPhaseEnded];
         [touchAry addObject:touch];
     }
+    CFRunLoopSourceContext context;
+    memset(&context, 0, sizeof(CFRunLoopSourceContext));
+    context.perform = eventSendCallback;
+    // content of context is copied
+    source = CFRunLoopSourceCreate(NULL, -1, &context);
+    CFRunLoopRef loop = CFRunLoopGetMain();
+    CFRunLoopAddSource(loop, source, kCFRunLoopCommonModes);
+//    CFRunLoopMode mode = (CFRunLoopMode)UITrackingRunLoopMode;
+//    CFRunLoopAddSource(loop, source, GSEventReceiveRunLoopMode);
 }
 
 + (UITouch* ) touch: (NSInteger) pointId {
@@ -80,43 +119,47 @@ void moveCursorTo(CGPoint point){
     return nil;
 }
 
-+ (NSInteger)fakeTouchId:(NSInteger)pointId AtPoint:(CGPoint)point withTouchPhase:(UITouchPhase)phase inWindow:(UIWindow*)window{
++ (NSInteger)fakeTouchId:(NSInteger)pointId AtPoint:(CGPoint)point withTouchPhase:(UITouchPhase)phase inWindow:(UIWindow*)window onView:(UIView*)view{
+    bool deleted = false;
+    UITouch* touch = NULL;
+    if(toRemove != NULL) {
+        touch = toRemove;
+        toRemove = NULL;
+        [livingTouchAry removeObjectIdenticalTo:touch];
+        deleted = true;
+    }
+    if(toStationarify != NULL) {
+        // in case this is changed during the operations
+        touch = toStationarify;
+        toStationarify = NULL;
+        if(touch.phase == UITouchPhaseBegan) {
+            [touch setPhaseAndUpdateTimestamp:UITouchPhaseStationary];
+        }
+    }
     pointId -= 1;
     // ideally should be phase began when this hit
     // but if by any means other phases come... well lets be forgiving
-    NSUInteger livingIndex = [livingTouchAry indexOfObjectIdenticalTo:touchAry[pointId]];
-    if(livingIndex == NSNotFound) {
-        if(phase == UITouchPhaseEnded) return -1;
-        UITouch *touch = [[UITouch alloc] initAtPoint:point inWindow:window];
-        livingIndex = livingTouchAry.count;
+    touch = touchAry[pointId];
+    bool old = [livingTouchAry containsObject:touch];
+    bool new = !old;
+    if(new) {
+        if(phase == UITouchPhaseEnded) return deleted;
+        touch = [[UITouch alloc] initAtPoint:point inWindow:window onView:view];
         [livingTouchAry addObject:touch];
         [touchAry setObject:touch atIndexedSubscript:pointId ];
-    }
-    UITouch *touch = [livingTouchAry objectAtIndex:livingIndex];
-    
-    [touch setLocationInWindow:point];
-    if(touch.phase!=UITouchPhaseBegan){
+    } else {
         [touch setPhaseAndUpdateTimestamp:phase];
+        [touch setLocationInWindow:point];
     }
-    
+//    CFRunLoopSourceContext context;
+//    CFRunLoopSourceGetContext(source, &context);
+
+    CFTypeRef delayRelease = CFBridgingRetain(safeTouchAry);
+    safeTouchAry = [[NSArray alloc] initWithArray:livingTouchAry copyItems:NO];
+    CFRunLoopSourceSignal(source);
+    CFBridgingRelease(delayRelease);
 //    UIEvent *event = [self eventWithTouches:livingTouchAry];
-    UIEvent *event = [[UIApplication sharedApplication] _touchesEvent];
-    dispatch_sync(dispatch_get_main_queue(), ^{
-        [event _clearTouches];
-        for (UITouch *aTouch in livingTouchAry) {
-            [event _addTouch:aTouch forDelayedDelivery:NO];
-        }
-        [[UIApplication sharedApplication] sendEvent:event];
-    });
-    if ((touch.phase==UITouchPhaseBegan)||touch.phase==UITouchPhaseMoved) {
-        [touch setPhaseAndUpdateTimestamp:UITouchPhaseStationary];
-    }
-    
-    if (phase == UITouchPhaseEnded) {
-        [livingTouchAry removeObjectAtIndex:livingIndex];
-//        [touchAry removeObjectAtIndex:pointId];
-    }
-    return livingIndex;
+    return deleted;
 }
 
 

--- a/PlayTools/Controls/PTFakeTouch/addition/UITouch-KIFAdditions.h
+++ b/PlayTools/Controls/PTFakeTouch/addition/UITouch-KIFAdditions.h
@@ -36,6 +36,7 @@ KW_FIX_CATEGORY_BUG_H(UITouch_KIFAdditions)
 - (id)initInView:(UIView *)view;
 - (id)initAtPoint:(CGPoint)point inView:(UIView *)view;
 - (id)initAtPoint:(CGPoint)point inWindow:(UIWindow *)window;
+- (id)initAtPoint:(CGPoint)point inWindow:(UIWindow *)window onView:(UIView*)view;
 - (id)initTouch;
 - (void)resetTouch;
 

--- a/PlayTools/Controls/PTFakeTouch/addition/UITouch-KIFAdditions.m
+++ b/PlayTools/Controls/PTFakeTouch/addition/UITouch-KIFAdditions.m
@@ -35,6 +35,12 @@ typedef struct {
 
 - (id)initAtPoint:(CGPoint)point inWindow:(UIWindow *)window;
 {
+    UIView *view = [window hitTest:point withEvent:nil];
+    return [self initAtPoint:point inWindow:window onView:view];
+}
+
+- (id)initAtPoint:(CGPoint)point inWindow:(UIWindow *)window onView:(UIView *)view;
+{
     self = [super init];
     if (self == nil) {
         return nil;
@@ -46,7 +52,7 @@ typedef struct {
     //[self setTapCount:1];
     [self _setLocationInWindow:point resetPrevious:YES];
     
-    UIView *hitTestView = [window hitTest:point withEvent:nil];
+    UIView *hitTestView = view;
     
     [self setView:hitTestView];
     [self setPhase:UITouchPhaseBegan];

--- a/PlayTools/Controls/PlayMice.swift
+++ b/PlayTools/Controls/PlayMice.swift
@@ -54,7 +54,7 @@ typealias ResponseBlockBool = @convention(block) (_ event: Any) -> Bool
     public func setupMouseMovedHandler() {
         for mouse in GCMouse.mice() {
             mouse.mouseInput?.mouseMovedHandler = { _, deltaX, deltaY in
-                Toucher.touchQueue.async {
+//                Toucher.touchQueue.async {
                     if !mode.visible {
                         if let draggableButton = DraggableButtonAction.activeButton {
                             draggableButton.onMouseMoved(deltaX: CGFloat(deltaX), deltaY: CGFloat(deltaY))
@@ -62,7 +62,7 @@ typealias ResponseBlockBool = @convention(block) (_ event: Any) -> Bool
                             self.camera?.updated(CGFloat(deltaX), CGFloat(deltaY))
                         }
                     }
-                }
+//                }
             }
         }
     }
@@ -186,8 +186,9 @@ final class CameraControl {
         Toucher.touchcam(point: self.location, phase: UITouch.Phase.moved, tid: 1)
         let previous = sequence
 
-        delay(0.016) {
-            // if no other touch events in the past 0.016 sec
+        // if mouse not moving during this time, then an ended event is sent.
+        delay(0.2) {
+            // if no other touch events in this period
             if previous != self.sequence {
                 return
             }

--- a/PlayTools/Controls/PlayMice.swift
+++ b/PlayTools/Controls/PlayMice.swift
@@ -193,11 +193,11 @@ final class CameraControl {
             stationaryCount = 0
             Toucher.touchcam(point: self.center, phase: UITouch.Phase.began, tid: 1)
 
-            delay(0.5, closure: checkEnded)
+            delay(0.1, closure: checkEnded)
         }
         // if not moving fast, regard the user fine-tuning the camera(e.g. aiming)
         // so hold the touch for longer to avoid cold startup
-        if deltaX.magnitude + deltaY.magnitude > 10 {
+        if deltaX.magnitude + deltaY.magnitude > 12 {
             // if we had mistaken this as player aiming
             if self.idled {
 //                Toast.showOver(msg: "idled")

--- a/PlayTools/Controls/PlayMice.swift
+++ b/PlayTools/Controls/PlayMice.swift
@@ -152,7 +152,7 @@ final class CameraControl {
     var idled = false
     // in how many tests has this been identified as stationary
     var stationaryCount = 0
-    let stationaryThreshold = 3
+    let stationaryThreshold = 2
 
     @objc func checkEnded() {
         // if been stationary for enough time
@@ -197,9 +197,10 @@ final class CameraControl {
         }
         // if not moving fast, regard the user fine-tuning the camera(e.g. aiming)
         // so hold the touch for longer to avoid cold startup
-        if deltaX.magnitude + deltaY.magnitude > 4 {
+        if deltaX.magnitude + deltaY.magnitude > 10 {
             // if we had mistaken this as player aiming
             if self.idled {
+//                Toast.showOver(msg: "idled")
                 // since not aiming, re-touch to re-gain control
                 self.doLiftOff()
                 return
@@ -220,8 +221,8 @@ final class CameraControl {
         self.isMoving = false
         // ending and beginning too frequently leads to the beginning event not recognized
         // so let the beginning event wait some time
-        // 0.016 here is safe as long as the 0.016 above works
-        delay(0.016) {
+        // pause for one frame or two
+        delay(0.02) {
             self.cooldown = false
         }
         cooldown = true

--- a/PlayTools/Controls/PlayMice.swift
+++ b/PlayTools/Controls/PlayMice.swift
@@ -54,15 +54,13 @@ typealias ResponseBlockBool = @convention(block) (_ event: Any) -> Bool
     public func setupMouseMovedHandler() {
         for mouse in GCMouse.mice() {
             mouse.mouseInput?.mouseMovedHandler = { _, deltaX, deltaY in
-//                Toucher.touchQueue.async {
-                    if !mode.visible {
-                        if let draggableButton = DraggableButtonAction.activeButton {
-                            draggableButton.onMouseMoved(deltaX: CGFloat(deltaX), deltaY: CGFloat(deltaY))
-                        } else {
-                            self.camera?.updated(CGFloat(deltaX), CGFloat(deltaY))
-                        }
+                if !mode.visible {
+                    if let draggableButton = DraggableButtonAction.activeButton {
+                        draggableButton.onMouseMoved(deltaX: CGFloat(deltaX), deltaY: CGFloat(deltaY))
+                    } else {
+                        self.camera?.updated(CGFloat(deltaX), CGFloat(deltaY))
                     }
-//                }
+                }
             }
         }
     }
@@ -146,20 +144,44 @@ final class CameraControl {
 
     // if max speed of this touch is high
     var movingFast = false
-    // seq number for each move event. Used in closure to determine if this move is the last
-    var sequence = 0
     // like sequence but resets when touch begins. Used to calc touch duration
     var counter = 0
     // if should wait before beginning next touch
     var cooldown = false
     // if the touch point had been prevented from lifting off because of moving slow
     var idled = false
+    // in how many tests has this been identified as stationary
+    var stationaryCount = 0
+    let stationaryThreshold = 3
+
+    @objc func checkEnded() {
+        // if been stationary for enough time
+        if self.stationaryCount < self.stationaryThreshold {
+            self.stationaryCount += 1
+            self.delay(0.1, closure: checkEnded)
+            return
+        }
+        // and slow touch lasts for sufficient time
+        if self.movingFast || self.counter > 64 {
+            self.doLiftOff()
+        } else {
+            self.idled = true
+            // idle for at most 4 seconds
+            self.delay(4) {
+                if self.stationaryCount < self.stationaryThreshold {
+                    self.stationaryCount += 1
+                    self.delay(0.1, closure: self.checkEnded)
+                    return
+                }
+                self.doLiftOff()
+            }
+        }
+     }
 
     @objc func updated(_ deltaX: CGFloat, _ deltaY: CGFloat) {
         if mode.visible || cooldown {
             return
         }
-        sequence += 1
         // count touch duration
         counter += 1
         if !isMoving {
@@ -168,7 +190,10 @@ final class CameraControl {
             idled = false
             location = center
             counter = 0
+            stationaryCount = 0
             Toucher.touchcam(point: self.center, phase: UITouch.Phase.began, tid: 1)
+
+            delay(0.5, closure: checkEnded)
         }
         // if not moving fast, regard the user fine-tuning the camera(e.g. aiming)
         // so hold the touch for longer to avoid cold startup
@@ -184,29 +209,7 @@ final class CameraControl {
         self.location.x += deltaX * CGFloat(PlaySettings.shared.sensitivity)
         self.location.y -= deltaY * CGFloat(PlaySettings.shared.sensitivity)
         Toucher.touchcam(point: self.location, phase: UITouch.Phase.moved, tid: 1)
-        let previous = sequence
-
-        // if mouse not moving during this time, then an ended event is sent.
-        delay(0.2) {
-            // if no other touch events in this period
-            if previous != self.sequence {
-                return
-            }
-            // and slow touch lasts for sufficient time
-            if self.movingFast || self.counter > 64 {
-                self.doLiftOff()
-            } else {
-                self.idled = true
-                // idle for at most 4 seconds
-                self.delay(4) {
-                    if previous != self.sequence {
-                        return
-                    }
-                    self.doLiftOff()
-                }
-            }
-         }
-
+        stationaryCount = 0
     }
 
     public func doLiftOff() {
@@ -225,7 +228,6 @@ final class CameraControl {
     }
 
     func stop() {
-        sequence = 0
         self.doLiftOff()
     }
 }

--- a/PlayTools/Controls/Toucher.swift
+++ b/PlayTools/Controls/Toucher.swift
@@ -9,14 +9,18 @@ import UIKit
 class Toucher {
 
     static var keyWindow: UIWindow?
+    static var keyView: UIView?
     static var touchQueue = DispatchQueue.init(label: "playcover.toucher", qos: .userInteractive)
 
     static func touchcam(point: CGPoint, phase: UITouch.Phase, tid: Int) {
         touchQueue.async {
             if keyWindow == nil {
                 keyWindow = screen.keyWindow
+                DispatchQueue.main.sync {
+                    keyView = keyWindow?.hitTest(point, with: nil)
+                }
             }
-            PTFakeMetaTouch.fakeTouchId(tid, at: point, with: phase, in: keyWindow)
+            PTFakeMetaTouch.fakeTouchId(tid, at: point, with: phase, in: keyWindow, on: keyView)
         }
     }
 }

--- a/PlayTools/Controls/Toucher.swift
+++ b/PlayTools/Controls/Toucher.swift
@@ -8,13 +8,13 @@ import UIKit
 
 class Toucher {
 
-    static var keyWindow: UIWindow?
-    static var keyView: UIView?
+    static weak var keyWindow: UIWindow?
+    static weak var keyView: UIView?
     static var touchQueue = DispatchQueue.init(label: "playcover.toucher", qos: .userInteractive)
 
     static func touchcam(point: CGPoint, phase: UITouch.Phase, tid: Int) {
         touchQueue.async {
-            if keyWindow == nil {
+            if keyWindow == nil || keyView == nil {
                 keyWindow = screen.keyWindow
                 DispatchQueue.main.sync {
                     keyView = keyWindow?.hitTest(point, with: nil)


### PR DESCRIPTION
Must have fixed https://github.com/PlayCover/PlayCover/issues/116

With this PR, it <del>makes renderring stuck too</del> does not stuck on fake touch as long as the frame rate does not drop dramatically. The code run on the main thread is executed via runloop's source0, which is the same as native event handling. And it is completely concurrent with fake touch thread. 

The source order is set as -1, which is the same as that of the native event handler. In theory, this should not be slower than if you really touch the screen with your finger. If it ever stutters, it should also stutter if you drag the screen by curcor.

I tested it by poping a toast for every mouse move event, which could end up with a hundred toasts on screen at the same time, which makes Genshin really stuck. Even in this situation, I can control my camera in most times. It only loses control if the frame rate is as low as about 10.

Multi-thread programming gives me a lot of headache. There is still a really little chance that the drag of camera control becomes a touch at it's end point in really very high load cases. If you run into this, your frame rate cannot exceed 10 and you really need to turn down graphics quality.