### PR TITLE
Better Detail for DiscordActivity

### DIFF
--- a/PlayTools/DiscordActivity/DiscordIPC.swift
+++ b/PlayTools/DiscordActivity/DiscordIPC.swift
@@ -38,7 +38,7 @@ class DiscordIPC {
             activity.details = custom.details
         }
 
-        let poweredStr = "Powered by PlayCover"
+        let poweredStr = "On Apple Silicon Mac"
         if custom.state.isEmpty {
             activity.state = poweredStr
         } else {


### PR DESCRIPTION
Changes `Powered by PlayCover` to `On Apple Silicon Mac` for example:
```
PlayCover
Playing Catalyst Black
On Apple Silicon Mac
Download PlayCover
```