### PR TITLE
Improve camera control

### DIFF
--- a/PlayTools/Controls/PlayMice.swift
+++ b/PlayTools/Controls/PlayMice.swift
@@ -178,40 +178,22 @@ final class CameraControl {
         Toucher.touchQueue.asyncAfter(deadline: when, execute: closure)
     }
 
-    // if max speed of this touch is high
-    var movingFast = false
     // like sequence but resets when touch begins. Used to calc touch duration
     var counter = 0
     // if should wait before beginning next touch
     var cooldown = false
-    // if the touch point had been prevented from lifting off because of moving slow
-    var idled = false
     // in how many tests has this been identified as stationary
     var stationaryCount = 0
     let stationaryThreshold = 2
 
     @objc func checkEnded() {
         // if been stationary for enough time
-        if self.stationaryCount < self.stationaryThreshold {
+        if self.stationaryCount < self.stationaryThreshold || (self.stationaryCount < 20 - self.counter) {
             self.stationaryCount += 1
             self.delay(0.1, closure: checkEnded)
             return
         }
-        // and slow touch lasts for sufficient time
-        if self.movingFast || self.counter > 64 {
-            self.doLiftOff()
-        } else {
-            self.idled = true
-            // idle for at most 4 seconds
-            self.delay(4) {
-                if self.stationaryCount < self.stationaryThreshold {
-                    self.stationaryCount += 1
-                    self.delay(0.1, closure: self.checkEnded)
-                    return
-                }
-                self.doLiftOff()
-            }
-        }
+        self.doLiftOff()
      }
 
     @objc func updated(_ deltaX: CGFloat, _ deltaY: CGFloat) {
@@ -222,8 +204,6 @@ final class CameraControl {
         counter += 1
         if !isMoving {
             isMoving = true
-            movingFast = false
-            idled = false
             location = center
             counter = 0
             stationaryCount = 0
@@ -231,21 +211,12 @@ final class CameraControl {
 
             delay(0.1, closure: checkEnded)
         }
-        // if not moving fast, regard the user fine-tuning the camera(e.g. aiming)
-        // so hold the touch for longer to avoid cold startup
-        if deltaX.magnitude + deltaY.magnitude > 12 {
-            // if we had mistaken this as player aiming
-            if self.idled {
-//                Toast.showOver(msg: "idled")
-                // since not aiming, re-touch to re-gain control
-                self.doLiftOff()
-                return
-            }
-            movingFast = true
-        }
         self.location.x += deltaX * CGFloat(PlaySettings.shared.sensitivity)
         self.location.y -= deltaY * CGFloat(PlaySettings.shared.sensitivity)
         Toucher.touchcam(point: self.location, phase: UITouch.Phase.moved, tid: 1)
+        if stationaryCount >= self.stationaryThreshold {
+            self.counter = 0
+        }
         stationaryCount = 0
     }
 
@@ -254,6 +225,9 @@ final class CameraControl {
             return
         }
         Toucher.touchcam(point: self.location, phase: UITouch.Phase.ended, tid: 1)
+//        DispatchQueue.main.async {
+//            Toast.showOver(msg: "mouse released")
+//        }
         self.isMoving = false
         // ending and beginning too frequently leads to the beginning event not recognized
         // so let the beginning event wait some time

--- a/PlayTools/Controls/PlayMice.swift
+++ b/PlayTools/Controls/PlayMice.swift
@@ -190,7 +190,7 @@ final class CameraControl {
         // if been stationary for enough time
         if self.stationaryCount < self.stationaryThreshold || (self.stationaryCount < 20 - self.counter) {
             self.stationaryCount += 1
-            self.delay(0.1, closure: checkEnded)
+            self.delay(0.04, closure: checkEnded)
             return
         }
         self.doLiftOff()
@@ -209,12 +209,16 @@ final class CameraControl {
             stationaryCount = 0
             Toucher.touchcam(point: self.center, phase: UITouch.Phase.began, tid: 1)
 
-            delay(0.1, closure: checkEnded)
+            delay(0.01, closure: checkEnded)
+        }
+        if self.counter == 120 {
+            self.doLiftOff()
+            return
         }
         self.location.x += deltaX * CGFloat(PlaySettings.shared.sensitivity)
         self.location.y -= deltaY * CGFloat(PlaySettings.shared.sensitivity)
         Toucher.touchcam(point: self.location, phase: UITouch.Phase.moved, tid: 1)
-        if stationaryCount >= self.stationaryThreshold {
+        if stationaryCount > self.stationaryThreshold {
             self.counter = 0
         }
         stationaryCount = 0


### PR DESCRIPTION
FIxes https://github.com/PlayCover/PlayCover/issues/379 and https://github.com/PlayCover/PlayCover/issues/388

https://github.com/PlayCover/PlayTools/pull/10 fixed aiming and https://github.com/PlayCover/PlayTools/pull/34 changed logic of lifting off. Camera control code got too complicated after those two PRs. This PR cleans up the logic and changes some control parameters (i.e. when should camera touch point lift off) to fix the mentioned issues.

Direct cause of the issue is that the "slowness threshold" set too high. Some fast moves are recognised as slow moves. But instead of simply lowering the threshold, I also want to simplify the code, so that it's easier for others to understand.

Basically, camera control touch point must lift off at appropriate time, to prevent issues like in https://github.com/PlayCover/PlayCover/issues/379. It also cannot lift off too frequently, otherwise it would be impossible to fine tune camera orientation. The code thus detects player behaviour to lift off at different frequency.

In https://github.com/PlayCover/PlayTools/pull/10, it detects mouse moving speed. With https://github.com/PlayCover/PlayTools/pull/34, it is now possible for a simpler implementation, which is to determine lift off time based on number of events passed. This is equivalent to detecting the distance of mouse movement, which is a more precise (i.e. less false positive) feature to determine player aiming, than previous detection on moving speed.