### PR TITLE
Add iPad Pro 6th generation (M2) model identifier

### DIFF
--- a/PlayTools/PlaySettings.swift
+++ b/PlayTools/PlaySettings.swift
@@ -49,6 +49,8 @@ let settings = PlaySettings.shared
             return "J320xAP"
         case "iPad13,8":
             return "J522AP"
+        case "iPad14,5":
+            return "A2436"
         case "iPhone14,3":
             return "A2645"
         case "iPhone15,3":

--- a/PlayTools/PlaySettings.swift
+++ b/PlayTools/PlaySettings.swift
@@ -49,10 +49,10 @@ let settings = PlaySettings.shared
             return "J320xAP"
         case "iPad13,8":
             return "J522AP"
-        case "iPhone15,3":
-            return "A2896"
         case "iPhone14,3":
             return "A2645"
+        case "iPhone15,3":
+            return "A2896"
         default:
             return "J320xAP"
         }


### PR DESCRIPTION
Add the iPad Pro 6th generation (M2) model identifier.