### PR TITLE
Fix menubuilder swizzle

### DIFF
--- a/PlayTools/Controls/PTFakeTouch/NSObject+Swizzle.m
+++ b/PlayTools/Controls/PTFakeTouch/NSObject+Swizzle.m
@@ -56,10 +56,22 @@
             [objc_getClass("FBSSceneSettings") swizzleInstanceMethod:@selector(bounds) withMethod:@selector(hook_bounds)];
             [objc_getClass("FBSDisplayMode") swizzleInstanceMethod:@selector(size) withMethod:@selector(hook_size)];
         }
+        
+        [objc_getClass("_UIMenuBuilder") swizzleInstanceMethod:sel_getUid("initWithRootMenu:") withMethod:@selector(initWithRootMenuHook:)];
 
         [objc_getClass("IOSViewController") swizzleInstanceMethod:@selector(prefersPointerLocked) withMethod:@selector(hook_prefersPointerLocked)];
-        [self swizzleInstanceMethod:@selector(init) withMethod:@selector(hook_init)];
     });
+}
+
+bool menuWasCreated = false;
+- (id) initWithRootMenuHook:(id)rootMenu {
+    self = [self initWithRootMenuHook:rootMenu];
+    if (!menuWasCreated) {
+        [PlayCover initMenuWithMenu: self];
+        menuWasCreated = TRUE;
+    }
+    
+    return self;
 }
 
 - (BOOL) hook_prefersPointerLocked {
@@ -76,14 +88,6 @@
 
 - (CGSize) hook_size {
     return [PlayScreen sizeAspectRatio:[self hook_size]];
-}
-
-- (id) hook_init {
-    if ([[self class] isEqual: NSClassFromString(@"_UIMenuBuilder")]) {
-        [PlayCover initMenuWithMenu: self];
-    }
-    
-    return self;
 }
 
 @end

--- a/PlayTools/Controls/PTFakeTouch/NSObject+Swizzle.m
+++ b/PlayTools/Controls/PTFakeTouch/NSObject+Swizzle.m
@@ -47,20 +47,17 @@
 
 + (void) load
 {
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-        // TODO: UINSview
+    // TODO: UINSview
 
-        if ([[PlaySettings shared] adaptiveDisplay]) {
-            [objc_getClass("FBSSceneSettings") swizzleInstanceMethod:@selector(frame) withMethod:@selector(hook_frame)];
-            [objc_getClass("FBSSceneSettings") swizzleInstanceMethod:@selector(bounds) withMethod:@selector(hook_bounds)];
-            [objc_getClass("FBSDisplayMode") swizzleInstanceMethod:@selector(size) withMethod:@selector(hook_size)];
-        }
-        
-        [objc_getClass("_UIMenuBuilder") swizzleInstanceMethod:sel_getUid("initWithRootMenu:") withMethod:@selector(initWithRootMenuHook:)];
+    if ([[PlaySettings shared] adaptiveDisplay]) {
+        [objc_getClass("FBSSceneSettings") swizzleInstanceMethod:@selector(frame) withMethod:@selector(hook_frame)];
+        [objc_getClass("FBSSceneSettings") swizzleInstanceMethod:@selector(bounds) withMethod:@selector(hook_bounds)];
+        [objc_getClass("FBSDisplayMode") swizzleInstanceMethod:@selector(size) withMethod:@selector(hook_size)];
+    }
+    
+    [objc_getClass("_UIMenuBuilder") swizzleInstanceMethod:sel_getUid("initWithRootMenu:") withMethod:@selector(initWithRootMenuHook:)];
 
-        [objc_getClass("IOSViewController") swizzleInstanceMethod:@selector(prefersPointerLocked) withMethod:@selector(hook_prefersPointerLocked)];
-    });
+    [objc_getClass("IOSViewController") swizzleInstanceMethod:@selector(prefersPointerLocked) withMethod:@selector(hook_prefersPointerLocked)];
 }
 
 bool menuWasCreated = false;


### PR DESCRIPTION
Now the check for _UIMenuBuilder won't happen every single time an object is initialized.  Not only was this terrible for performance, the original hook is most likely the cause of some odd bugs.  For example, the hook may return an initialized object when it should return NULL and thus altering control flow in unpredictable ways.  Personal observation: I had two virtual synthesizers that would crash at random times before this fix. 
This change also fixes the endless `[MenuBuilder] Duplicates existing --` warnings when attached to a debugger.