### PR TITLE
Change behaviour of the _UIMenuBuilder swizzle

### DIFF
--- a/PlayTools/Controls/PTFakeTouch/NSObject+Swizzle.m
+++ b/PlayTools/Controls/PTFakeTouch/NSObject+Swizzle.m
@@ -54,21 +54,9 @@
         [objc_getClass("FBSSceneSettings") swizzleInstanceMethod:@selector(bounds) withMethod:@selector(hook_bounds)];
         [objc_getClass("FBSDisplayMode") swizzleInstanceMethod:@selector(size) withMethod:@selector(hook_size)];
     }
-    
-    [objc_getClass("_UIMenuBuilder") swizzleInstanceMethod:sel_getUid("initWithRootMenu:") withMethod:@selector(initWithRootMenuHook:)];
 
     [objc_getClass("IOSViewController") swizzleInstanceMethod:@selector(prefersPointerLocked) withMethod:@selector(hook_prefersPointerLocked)];
-}
-
-bool menuWasCreated = false;
-- (id) initWithRootMenuHook:(id)rootMenu {
-    self = [self initWithRootMenuHook:rootMenu];
-    if (!menuWasCreated) {
-        [PlayCover initMenuWithMenu: self];
-        menuWasCreated = TRUE;
-    }
-    
-    return self;
+    [self swizzleInstanceMethod:@selector(init) withMethod:@selector(hook_init)];
 }
 
 - (BOOL) hook_prefersPointerLocked {
@@ -87,4 +75,16 @@ bool menuWasCreated = false;
     return [PlayScreen sizeAspectRatio:[self hook_size]];
 }
 
+bool menuWasCreated = false;
+
+-(id) hook_init {
+    if (!menuWasCreated) {
+        if ([[self class] isEqual: NSClassFromString(@"_UIMenuBuilder")]) {
+            [PlayCover initMenuWithMenu: self];
+            menuWasCreated = TRUE;
+        }
+    }
+    
+    return self;
+}
 @end


### PR DESCRIPTION
This PR changes the behaviour of the _UIMenuBuilder swizzle in order to address bugs both caused and fixed in https://github.com/PlayCover/PlayTools/commit/e3e422b1df55dc1e91cdd6ca1ba500fe31a7e6fb and https://github.com/PlayCover/PlayTools/pull/57 .

Among other things, #57 fixed a regression in game performance and a regression in the game Sonic the Hedgehog (see https://github.com/PlayCover/PlayCover/issues/578 for more information) caused both in https://github.com/PlayCover/PlayTools/commit/e3e422b1df55dc1e91cdd6ca1ba500fe31a7e6fb, and in turn caused a regression in which certain games wouldn't start PlayTools correctly. Such are the likes of Crossy Road, Dadish and Dadish 3.