### PR TITLE
Fix PlayTools not loading for some apps in #57

### DIFF
--- a/PlayTools/PlayCover.swift
+++ b/PlayTools/PlayCover.swift
@@ -19,15 +19,8 @@ public class PlayCover: NSObject {
     }
 
     @objc static public func initMenu(menu: NSObject) {
-        delay(0.005) {
-            guard let menuBuilder = menu as? UIMenuBuilder else { return }
-
-            shared.menuController = MenuController(with: menuBuilder)
-            delay(0.005) {
-                UIMenuSystem.main.setNeedsRebuild()
-                UIMenuSystem.main.setNeedsRevalidate()
-            }
-        }
+        guard let menuBuilder = menu as? UIMenuBuilder else { return }
+        shared.menuController = MenuController(with: menuBuilder)
     }
 
     static public func quitWhenClose() {


### PR DESCRIPTION
The problem with seems to have been a combination of the delay in `initMenu` and/or apps having their own `NSObject` categories.

Fixes:
- Remove delay in `initMenu`
- Apply method swizzling from a class that will not have categories or subclasses (mildly "enforced" with a "hidden" attribute)