### PR TITLE
Toucher Refactor: decouple touch point ID from touch action ID

### DIFF
--- a/PlayTools/Controls/PlayAction.swift
+++ b/PlayTools/Controls/PlayAction.swift
@@ -47,7 +47,7 @@ class ButtonAction: Action {
         }
     }
 
-    init(id: Int, keyCode: GCKeyCode, keyName: String, point: CGPoint) {
+    init(keyCode: GCKeyCode, keyName: String, point: CGPoint) {
         self.keyCode = keyCode
         self.keyName = keyName
         self.point = point
@@ -69,10 +69,9 @@ class ButtonAction: Action {
         }
     }
 
-    convenience init(id: Int, data: Button) {
+    convenience init(data: Button) {
         let keyCode = GCKeyCode(rawValue: data.keyCode)
         self.init(
-            id: id,
             keyCode: keyCode,
             keyName: data.keyName,
             point: CGPoint(
@@ -92,9 +91,9 @@ class ButtonAction: Action {
 class DraggableButtonAction: ButtonAction {
     var releasePoint: CGPoint
 
-    override init(id: Int, keyCode: GCKeyCode, keyName: String, point: CGPoint) {
+    override init(keyCode: GCKeyCode, keyName: String, point: CGPoint) {
         self.releasePoint = point
-        super.init(id: id, keyCode: keyCode, keyName: keyName, point: point)
+        super.init(keyCode: keyCode, keyName: keyName, point: point)
         _ = PlayMice.shared.setupThumbstickChangedHandler(name: keyName)
     }
 
@@ -130,7 +129,7 @@ class ConcreteJoystickAction: Action {
     var sensitivity: CGFloat
     var begun = false
 
-    init(id: Int, data: Joystick) {
+    init(data: Joystick) {
         self.center = CGPoint(
             x: data.transform.xCoord.absoluteX,
             y: data.transform.yCoord.absoluteY)
@@ -183,7 +182,7 @@ class JoystickAction: Action {
     var id: Int?
     var moving = false
 
-    init(id: Int, keys: [GCKeyCode], center: CGPoint, shift: CGFloat) {
+    init(keys: [GCKeyCode], center: CGPoint, shift: CGFloat) {
         self.keys = keys
         self.center = center
         self.shift = shift / 2
@@ -200,9 +199,8 @@ class JoystickAction: Action {
         }
     }
 
-    convenience init(id: Int, data: Joystick) {
+    convenience init(data: Joystick) {
         self.init(
-            id: id,
             keys: [
                 GCKeyCode(rawValue: CFIndex(data.upKeyCode)),
                 GCKeyCode(rawValue: CFIndex(data.downKeyCode)),

--- a/PlayTools/Controls/PlayInput.swift
+++ b/PlayTools/Controls/PlayInput.swift
@@ -19,33 +19,27 @@ class PlayInput {
 
     func parseKeymap() {
         actions = []
-        // ID starts from 1
-        var counter = 1
         for button in keymap.keymapData.buttonModels {
-            actions.append(ButtonAction(id: counter, data: button))
-            counter += 1
+            actions.append(ButtonAction(data: button))
         }
 
         for draggableButton in keymap.keymapData.draggableButtonModels {
-                actions.append(DraggableButtonAction(id: counter, data: draggableButton))
-                counter += 1
+                actions.append(DraggableButtonAction(data: draggableButton))
         }
 
         for mouse in keymap.keymapData.mouseAreaModel {
             if mouse.keyName.hasSuffix("tick") || settings.mouseMapping {
-                actions.append(CameraAction(id: counter, data: mouse))
-                counter += 1
+                actions.append(CameraAction(data: mouse))
             }
         }
 
         for joystick in keymap.keymapData.joystickModel {
             // Left Thumbstick, Right Thumbstick, Mouse
             if joystick.keyName.contains(Character("u")) {
-                actions.append(ConcreteJoystickAction(id: counter, data: joystick))
+                actions.append(ConcreteJoystickAction(data: joystick))
             } else { // Keyboard
-                actions.append(JoystickAction(id: counter, data: joystick))
+                actions.append(JoystickAction(data: joystick))
             }
-            counter += 1
         }
     }
 

--- a/PlayTools/Controls/PlayMice.swift
+++ b/PlayTools/Controls/PlayMice.swift
@@ -220,7 +220,7 @@ class CameraAction: Action {
         self.cooldown = false
     }
 
-    convenience init(id: Int, data: MouseArea) {
+    convenience init(data: MouseArea) {
         self.init(
             centerX: data.transform.xCoord.absoluteX,
             centerY: data.transform.yCoord.absoluteY)

--- a/PlayTools/Controls/Toucher.swift
+++ b/PlayTools/Controls/Toucher.swift
@@ -11,7 +11,7 @@ class Toucher {
     static weak var keyView: UIView?
     static var touchQueue = DispatchQueue.init(label: "playcover.toucher", qos: .userInteractive)
     static var nextId: Int = 0
-    static var idMap: [Int?] = []
+    static var idMap = [Int?](repeating: nil, count: 64)
     /**
      on invocations with phase "began", an int id is allocated, which can be used later to refer to this touch point.
      on invocations with phase "ended", id is set to nil representing the touch point is no longer valid.
@@ -20,6 +20,7 @@ class Toucher {
         if phase == UITouch.Phase.began {
             tid = nextId
             nextId += 1
+//            Toast.showOver(msg: tid!.description)
         }
         guard let bigId = tid else {
             // sending other phases with empty id is no-op

--- a/PlayTools/PlayScreen.swift
+++ b/PlayTools/PlayScreen.swift
@@ -20,7 +20,11 @@ extension CGSize {
     }
 
     func toAspectRatio() -> CGSize {
-        return CGSize(width: mainScreenHeight, height: mainScreenWidth)
+        if #available(macCatalyst 16.3, *) {
+            return CGSize(width: mainScreenWidth, height: mainScreenHeight)
+        } else {
+            return CGSize(width: mainScreenHeight, height: mainScreenWidth)
+        }
     }
 }
 
@@ -34,11 +38,11 @@ extension CGRect {
     }
 
     func toAspectRatio() -> CGRect {
-        return CGRect(x: minX, y: minY, width: mainScreenHeight, height: mainScreenWidth)
+        return CGRect(x: minX, y: minY, width: mainScreenWidth, height: mainScreenHeight)
     }
 
     func toAspectRatioReversed() -> CGRect {
-        return CGRect(x: minX, y: minY, width: mainScreenWidth, height: mainScreenHeight)
+        return CGRect(x: minX, y: minY, width: mainScreenHeight, height: mainScreenWidth)
     }
 }
 
@@ -65,11 +69,11 @@ public class PlayScreen: NSObject {
     @objc public static let shared = PlayScreen()
 
     @objc public static func frame(_ rect: CGRect) -> CGRect {
-        return rect.toAspectRatio()
+        return rect.toAspectRatioReversed()
     }
 
     @objc public static func bounds(_ rect: CGRect) -> CGRect {
-        return rect.toAspectRatioReversed()
+        return rect.toAspectRatio()
     }
 
     @objc public static func width(_ size: Int) -> Int {


### PR DESCRIPTION
When keymaps are loaded from the file, we assign an ID to each entry, which are later used as the touch point ID for that touch action. This method assumes that every touch action uses only one touch point, or at least unnecessarily exposes implementation details of how many touch points an action uses to a higher abstraction layer.

After this PR, when an action starts a touch point, it gets the touch point ID from the toucher. In the `Action` layer, we no longer need to assign a touch point ID in advance, but only need a variable (or multiple variables if it uses multiple touch points) to store the returned touch point ID. The refactor also makes it possible to store infinitely many entries in a keymap (previously has a upper limit of 100).

This refactor makes it easier to add new type of touch actions who use multiple touch points, such as camera scale.