### PR TITLE
Zoom camera in and out with scroll wheel

### DIFF
--- a/AKPlugin.swift
+++ b/AKPlugin.swift
@@ -76,6 +76,16 @@ class AKPlugin: NSObject, Plugin {
         })
     }
 
+    func setupScrollWheel(_ onMoved: @escaping(CGFloat, CGFloat) -> Bool) {
+        NSEvent.addLocalMonitorForEvents(matching: NSEvent.EventTypeMask.scrollWheel, handler: { event in
+            let consumed = onMoved(event.scrollingDeltaX, event.scrollingDeltaY)
+            if consumed {
+                return nil
+            }
+            return event
+        })
+    }
+
     func urlForApplicationWithBundleIdentifier(_ value: String) -> URL? {
         NSWorkspace.shared.urlForApplication(withBundleIdentifier: value)
     }

--- a/PlayTools/Controls/PlayAction.swift
+++ b/PlayTools/Controls/PlayAction.swift
@@ -38,7 +38,7 @@ class ButtonAction: Action {
 
     private func getChangedHandler<T1>(handler: ((T1, Float, Bool) -> Void)?) -> (T1, Float, Bool) -> Void {
         return { button, value, pressed in
-            if !mode.visible && !PlayInput.cmdPressed() {
+            if !PlayInput.cmdPressed() {
                 self.update(pressed: pressed)
             }
             if let previous = handler {
@@ -53,7 +53,7 @@ class ButtonAction: Action {
         self.point = point
         if PlayMice.shared.setMiceButtons(keyCode.rawValue, action: self) {
             // No more work to do for mouse buttons
-        } else if let gcKey = GCKeyboard.coalesced?.keyboardInput?.button(forKeyCode: keyCode) {
+        } else if let gcKey = GCKeyboard.coalesced!.keyboardInput!.button(forKeyCode: keyCode) {
             let handler = gcKey.pressedChangedHandler
             gcKey.pressedChangedHandler = getChangedHandler(handler: handler)
 
@@ -121,7 +121,7 @@ class DraggableButtonAction: ButtonAction {
     }
 }
 
-class ConcreteJoystickAction: Action {
+class ContinuousJoystickAction: Action {
     var key: String
     var center: CGPoint
     var position: CGPoint!

--- a/PlayTools/Controls/PlayAction.swift
+++ b/PlayTools/Controls/PlayAction.swift
@@ -47,7 +47,7 @@ class ButtonAction: Action {
         }
     }
 
-    init(id: Int, keyCode: GCKeyCode, keyName: String, point: CGPoint) {
+    init(keyCode: GCKeyCode, keyName: String, point: CGPoint) {
         self.keyCode = keyCode
         self.keyName = keyName
         self.point = point
@@ -69,10 +69,9 @@ class ButtonAction: Action {
         }
     }
 
-    convenience init(id: Int, data: Button) {
+    convenience init(data: Button) {
         let keyCode = GCKeyCode(rawValue: data.keyCode)
         self.init(
-            id: id,
             keyCode: keyCode,
             keyName: data.keyName,
             point: CGPoint(
@@ -92,9 +91,9 @@ class ButtonAction: Action {
 class DraggableButtonAction: ButtonAction {
     var releasePoint: CGPoint
 
-    override init(id: Int, keyCode: GCKeyCode, keyName: String, point: CGPoint) {
+    override init(keyCode: GCKeyCode, keyName: String, point: CGPoint) {
         self.releasePoint = point
-        super.init(id: id, keyCode: keyCode, keyName: keyName, point: point)
+        super.init(keyCode: keyCode, keyName: keyName, point: point)
         _ = PlayMice.shared.setupThumbstickChangedHandler(name: keyName)
     }
 
@@ -130,7 +129,7 @@ class ConcreteJoystickAction: Action {
     var sensitivity: CGFloat
     var begun = false
 
-    init(id: Int, data: Joystick) {
+    init(data: Joystick) {
         self.center = CGPoint(
             x: data.transform.xCoord.absoluteX,
             y: data.transform.yCoord.absoluteY)
@@ -183,7 +182,7 @@ class JoystickAction: Action {
     var id: Int?
     var moving = false
 
-    init(id: Int, keys: [GCKeyCode], center: CGPoint, shift: CGFloat) {
+    init(keys: [GCKeyCode], center: CGPoint, shift: CGFloat) {
         self.keys = keys
         self.center = center
         self.shift = shift / 2
@@ -200,9 +199,8 @@ class JoystickAction: Action {
         }
     }
 
-    convenience init(id: Int, data: Joystick) {
+    convenience init(data: Joystick) {
         self.init(
-            id: id,
             keys: [
                 GCKeyCode(rawValue: CFIndex(data.upKeyCode)),
                 GCKeyCode(rawValue: CFIndex(data.downKeyCode)),

--- a/PlayTools/Controls/PlayInput.swift
+++ b/PlayTools/Controls/PlayInput.swift
@@ -79,12 +79,10 @@ class PlayInput {
             }
         }
         for mouse in GCMouse.mice() {
-            mouse.mouseInput?.mouseMovedHandler = { _, deltaX, deltaY in
-                if editor.editorMode {
-//                    EditorController.shared.setKey("Mouse")
-                } else {
-                    PlayMice.shared.handleMouseMoved(deltaX: deltaX, deltaY: deltaY)
-                }
+            if settings.mouseMapping {
+                mouse.mouseInput?.mouseMovedHandler = PlayMice.shared.handleMouseMoved
+            } else {
+                mouse.mouseInput?.mouseMovedHandler = PlayMice.shared.handleFakeMouseMoved
             }
         }
 

--- a/PlayTools/Controls/PlayInput.swift
+++ b/PlayTools/Controls/PlayInput.swift
@@ -19,33 +19,27 @@ class PlayInput {
 
     func parseKeymap() {
         actions = []
-        // ID starts from 1
-        var counter = 1
         for button in keymap.keymapData.buttonModels {
-            actions.append(ButtonAction(id: counter, data: button))
-            counter += 1
+            actions.append(ButtonAction(data: button))
         }
 
         for draggableButton in keymap.keymapData.draggableButtonModels {
-                actions.append(DraggableButtonAction(id: counter, data: draggableButton))
-                counter += 1
+                actions.append(DraggableButtonAction(data: draggableButton))
         }
 
         for mouse in keymap.keymapData.mouseAreaModel {
             if mouse.keyName.hasSuffix("tick") || settings.mouseMapping {
-                actions.append(CameraAction(id: counter, data: mouse))
-                counter += 1
+                actions.append(CameraAction(data: mouse))
             }
         }
 
         for joystick in keymap.keymapData.joystickModel {
             // Left Thumbstick, Right Thumbstick, Mouse
             if joystick.keyName.contains(Character("u")) {
-                actions.append(ConcreteJoystickAction(id: counter, data: joystick))
+                actions.append(ConcreteJoystickAction(data: joystick))
             } else { // Keyboard
-                actions.append(JoystickAction(id: counter, data: joystick))
+                actions.append(JoystickAction(data: joystick))
             }
-            counter += 1
         }
     }
 

--- a/PlayTools/Controls/PlayMice.swift
+++ b/PlayTools/Controls/PlayMice.swift
@@ -309,10 +309,6 @@ class SwipeAction: Action {
             Toucher.touchcam(point: location, phase: UITouch.Phase.began, tid: &id)
             delay(0.01, closure: checkEnded)
         }
-        if self.counter == 120 {
-            self.doLiftOff()
-            return
-        }
         self.location.x += deltaX
         self.location.y -= deltaY
         Toucher.touchcam(point: self.location, phase: UITouch.Phase.moved, tid: &id)

--- a/PlayTools/Controls/PlayMice.swift
+++ b/PlayTools/Controls/PlayMice.swift
@@ -132,16 +132,13 @@ public class PlayMice {
         let sensy = CGFloat(PlaySettings.shared.sensitivity)
         let cgDx = CGFloat(deltaX) * sensy,
             cgDy = CGFloat(deltaY) * sensy
-        for name in ["", PlayMice.elementName] {
-            if let draggableUpdate = self.draggableHandler[name] {
-                draggableUpdate(cgDx, cgDy)
-                return
-            }
+        let name = PlayMice.elementName
+        if let draggableUpdate = self.draggableHandler[name] {
+            draggableUpdate(cgDx, cgDy)
+            return
         }
-        for name in ["", PlayMice.elementName] {
-            self.cameraMoveHandler[name]?(cgDx, cgDy)
-            self.joystickHandler[name]?(cgDx, cgDy)
-        }
+        self.cameraMoveHandler[name]?(cgDx, cgDy)
+        self.joystickHandler[name]?(cgDx, cgDy)
     }
 
     public func stop() {

--- a/PlayTools/Controls/PlayMice.swift
+++ b/PlayTools/Controls/PlayMice.swift
@@ -220,7 +220,7 @@ class CameraAction: Action {
         self.cooldown = false
     }
 
-    convenience init(id: Int, data: MouseArea) {
+    convenience init(data: MouseArea) {
         self.init(
             centerX: data.transform.xCoord.absoluteX,
             centerY: data.transform.yCoord.absoluteY)

--- a/PlayTools/Controls/PlayMice.swift
+++ b/PlayTools/Controls/PlayMice.swift
@@ -19,6 +19,9 @@ public class PlayMice {
             setupMouseButton(_up: 2, _down: 4)
             setupMouseButton(_up: 8, _down: 16)
             setupMouseButton(_up: 33554432, _down: 67108864)
+            if !acceptMouseEvents {
+                setupScrollWheelHandler()
+            }
             PlayMice.isInit = true
         }
     }
@@ -27,10 +30,11 @@ public class PlayMice {
     var fakedMousePressed: Bool {fakedMouseTouchPointId != nil}
     private var thumbstickVelocity: CGVector = CGVector.zero
     public var draggableHandler: [String: (CGFloat, CGFloat) -> Void] = [:],
-               cameraHandler: [String: (CGFloat, CGFloat) -> Void] = [:],
+               cameraMoveHandler: [String: (CGFloat, CGFloat) -> Void] = [:],
+               cameraScaleHandler: [String: (CGFloat, CGFloat) -> Void] = [:],
                joystickHandler: [String: (CGFloat, CGFloat) -> Void] = [:]
 
-    public var cursorPos: CGPoint {
+    public func cursorPos() -> CGPoint {
         var point = CGPoint(x: 0, y: 0)
         point = AKInterface.shared!.mousePoint
         let rect = AKInterface.shared!.windowFrame
@@ -58,6 +62,17 @@ public class PlayMice {
         return vector.dx.magnitude + vector.dy.magnitude > 0.2
     }
 
+    public func setupScrollWheelHandler() {
+//        AKInterface.shared!.setupScrollWheel({deltaX, deltaY in
+//            if let cameraScale = self.cameraScaleHandler[PlayMice.elementName] {
+//                cameraScale(deltaX, deltaY)
+//                let eventConsumed = !mode.visible
+//                return eventConsumed
+//            }
+//            return false
+//        })
+    }
+
     public func setupThumbstickChangedHandler(name: String) -> Bool {
         if let thumbstick = GCController.current?.extendedGamepad?.elements[name] as? GCControllerDirectionPad {
             thumbstick.valueChangedHandler = { _, deltaX, deltaY in
@@ -83,7 +98,7 @@ public class PlayMice {
 //            Toast.showOver(msg: "polling")
 //        }
         let draggableUpdate = self.draggableHandler[name]
-        let cameraUpdate = self.cameraHandler[name]
+        let cameraUpdate = self.cameraMoveHandler[name]
         if  draggableUpdate == nil && cameraUpdate == nil {
             return nil
         }
@@ -95,7 +110,7 @@ public class PlayMice {
                     captured = true
                 }
                 if !captured {
-                    if let cameraUpdate = self.cameraHandler[name] {
+                    if let cameraUpdate = self.cameraMoveHandler[name] {
                         cameraUpdate(self.thumbstickVelocity.dx, self.thumbstickVelocity.dy)
                     }
                 }
@@ -107,18 +122,16 @@ public class PlayMice {
         }
     }
 
-    public func handleMouseMoved(deltaX: Float, deltaY: Float) {
-        if self.acceptMouseEvents {
-            if self.fakedMousePressed {
-                Toucher.touchcam(point: self.cursorPos, phase: UITouch.Phase.moved, tid: &fakedMouseTouchPointId)
-            }
-            return
+    public func handleFakeMouseMoved(_: GCMouseInput, deltaX: Float, deltaY: Float) {
+        if self.fakedMousePressed {
+            Toucher.touchcam(point: self.cursorPos(), phase: UITouch.Phase.moved, tid: &fakedMouseTouchPointId)
         }
-        if mode.visible {
-            return
-        }
-        let cgDx = CGFloat(deltaX) * CGFloat(PlaySettings.shared.sensitivity),
-            cgDy = CGFloat(deltaY) * CGFloat(PlaySettings.shared.sensitivity)
+    }
+
+    public func handleMouseMoved(_: GCMouseInput, deltaX: Float, deltaY: Float) {
+        let sensy = CGFloat(PlaySettings.shared.sensitivity)
+        let cgDx = CGFloat(deltaX) * sensy,
+            cgDy = CGFloat(deltaY) * sensy
         for name in ["", PlayMice.elementName] {
             if let draggableUpdate = self.draggableHandler[name] {
                 draggableUpdate(cgDx, cgDy)
@@ -126,21 +139,17 @@ public class PlayMice {
             }
         }
         for name in ["", PlayMice.elementName] {
-            if let cameraUpdate = self.cameraHandler[name] {
-                cameraUpdate(cgDx, cgDy)
-            }
-            if let joystickUpdate = self.joystickHandler[name] {
-                joystickUpdate(cgDx, cgDy)
-            }
+            self.cameraMoveHandler[name]?(cgDx, cgDy)
+            self.joystickHandler[name]?(cgDx, cgDy)
         }
     }
 
     public func stop() {
-//        draggableJobs.removeAll()
-//        acceleratedJobs.removeAll()
-//        movedJobs.removeAll()
         mouseActions.keys.forEach { key in
             mouseActions[key] = []
+        }
+        for mouse in GCMouse.mice() {
+            mouse.mouseInput?.mouseMovedHandler = { _, _, _ in}
         }
     }
 
@@ -170,20 +179,21 @@ public class PlayMice {
             return true
         }
         if self.acceptMouseEvents {
+            let curPos = self.cursorPos()
             if state {
                 if !self.fakedMousePressed
                     // For traffic light buttons when not fullscreen
-                    && self.cursorPos.y > 0
+                    && curPos.y > 0
                     // For traffic light buttons when fullscreen
                     && isEventWindow {
-                    Toucher.touchcam(point: self.cursorPos,
+                    Toucher.touchcam(point: curPos,
                                      phase: UITouch.Phase.began,
                                      tid: &fakedMouseTouchPointId)
                     return false
                 }
             } else {
                 if self.fakedMousePressed {
-                    Toucher.touchcam(point: self.cursorPos, phase: UITouch.Phase.ended, tid: &fakedMouseTouchPointId)
+                    Toucher.touchcam(point: curPos, phase: UITouch.Phase.ended, tid: &fakedMouseTouchPointId)
                     return false
                 }
             }
@@ -210,25 +220,48 @@ public class PlayMice {
 }
 
 class CameraAction: Action {
-    var center: CGPoint = CGPoint.zero
-    var location: CGPoint = CGPoint.zero
+    var swipeMove, swipeScale1, swipeScale2: SwipeAction
     var key: String!
-    private var id: Int?
-    init(centerX: CGFloat = screen.width / 2, centerY: CGFloat = screen.height / 2) {
-        self.center = CGPoint(x: centerX, y: centerY)
+    var center: CGPoint
+    init(data: MouseArea) {
+        self.key = data.keyName
+        let centerX = data.transform.xCoord.absoluteX
+        let centerY = data.transform.yCoord.absoluteY
+        center = CGPoint(x: centerX, y: centerY)
+        swipeMove = SwipeAction()
+        swipeScale1 = SwipeAction()
+        swipeScale2 = SwipeAction()
+        _ = PlayMice.shared.setupThumbstickChangedHandler(name: key)
+        PlayMice.shared.cameraMoveHandler[key] = self.moveUpdated
+        PlayMice.shared.cameraScaleHandler[PlayMice.elementName] = self.scaleUpdated
+    }
+    func moveUpdated(_ deltaX: CGFloat, _ deltaY: CGFloat) {
+        swipeMove.move(from: {return center}, deltaX: deltaX, deltaY: deltaY)
+    }
+
+    func scaleUpdated(_ deltaX: CGFloat, _ deltaY: CGFloat) {
+        swipeScale1.move(from: {return CGPoint(x: center.x, y: center.y + 200)}, deltaX: 0, deltaY: deltaY)
+        swipeScale2.move(from: {return CGPoint(x: center.x, y: center.y - 200)}, deltaX: 0, deltaY: -deltaY)
+    }
+    // Event handlers SHOULD be SMALL
+    // DO NOT check things like mode.visible in an event handler
+    // change the handler itself instead
+    func dragUpdated(_ deltaX: CGFloat, _ deltaY: CGFloat) {
+        swipeMove.move(from: PlayMice.shared.cursorPos, deltaX: deltaX, deltaY: deltaY)
+    }
+
+    func invalidate() {
+        PlayMice.shared.cameraMoveHandler.removeValue(forKey: key)
+    }
+}
+
+class SwipeAction: Action {
+    var location: CGPoint = CGPoint.zero
+    var id: Int?
+    init() {
         // in rare cases the cooldown reset task is lost by the dispatch queue
         self.cooldown = false
     }
-
-    convenience init(data: MouseArea) {
-        self.init(
-            centerX: data.transform.xCoord.absoluteX,
-            centerY: data.transform.yCoord.absoluteY)
-        self.key = data.keyName
-        _ = PlayMice.shared.setupThumbstickChangedHandler(name: key)
-        PlayMice.shared.cameraHandler[key] = self.updated
-    }
-    var isMoving = false
 
     func delay(_ delay: Double, closure: @escaping () -> Void) {
         let when = DispatchTime.now() + delay
@@ -243,29 +276,26 @@ class CameraAction: Action {
     var stationaryCount = 0
     let stationaryThreshold = 2
 
-    @objc func checkEnded() {
+    func checkEnded() {
         // if been stationary for enough time
         if self.stationaryCount < self.stationaryThreshold || (self.stationaryCount < 20 - self.counter) {
             self.stationaryCount += 1
-            self.delay(0.04, closure: checkEnded)
+            self.delay(0.04, closure: self.checkEnded)
             return
         }
         self.doLiftOff()
      }
 
-    @objc func updated(_ deltaX: CGFloat, _ deltaY: CGFloat) {
-        if mode.visible || cooldown {
-            return
-        }
+    public func move(from: ()->CGPoint, deltaX: CGFloat, deltaY: CGFloat) {
         // count touch duration
         counter += 1
-        if !isMoving {
-            isMoving = true
-            location = center
+        if id == nil {
+            if cooldown {
+                return
+            }
             counter = 0
-            stationaryCount = 0
-            Toucher.touchcam(point: self.center, phase: UITouch.Phase.began, tid: &id)
-
+            location = from()
+            Toucher.touchcam(point: location, phase: UITouch.Phase.began, tid: &id)
             delay(0.01, closure: checkEnded)
         }
         if self.counter == 120 {
@@ -279,11 +309,10 @@ class CameraAction: Action {
     }
 
     public func doLiftOff() {
-        if !self.isMoving {
+        if id == nil {
             return
         }
         Toucher.touchcam(point: self.location, phase: UITouch.Phase.ended, tid: &id)
-        self.isMoving = false
         // ending and beginning too frequently leads to the beginning event not recognized
         // so let the beginning event wait some time
         // pause for one frame or two
@@ -294,7 +323,6 @@ class CameraAction: Action {
     }
 
     func invalidate() {
-        PlayMice.shared.cameraHandler.removeValue(forKey: key)
-        self.doLiftOff()
+        // pass
     }
 }

--- a/PlayTools/Controls/Toucher.swift
+++ b/PlayTools/Controls/Toucher.swift
@@ -11,7 +11,7 @@ class Toucher {
     static weak var keyView: UIView?
     static var touchQueue = DispatchQueue.init(label: "playcover.toucher", qos: .userInteractive)
     static var nextId: Int = 0
-    static var idMap: [Int?] = []
+    static var idMap = [Int?](repeating: nil, count: 64)
     /**
      on invocations with phase "began", an int id is allocated, which can be used later to refer to this touch point.
      on invocations with phase "ended", id is set to nil representing the touch point is no longer valid.
@@ -20,6 +20,7 @@ class Toucher {
         if phase == UITouch.Phase.began {
             tid = nextId
             nextId += 1
+//            Toast.showOver(msg: tid!.description)
         }
         guard let bigId = tid else {
             // sending other phases with empty id is no-op

--- a/PlayTools/Keymap/EditorController.swift
+++ b/PlayTools/Keymap/EditorController.swift
@@ -58,11 +58,11 @@ class EditorController {
             // menu still holds this object until next responder hit test
             editorWindow = nil
             previousWindow?.makeKeyAndVisible()
-            mode.show(false)
+            PlayInput.shared.toggleEditor(show: false)
             focusedControl = nil
             Toast.showOver(msg: "Keymapping saved")
         } else {
-            mode.show(true)
+            PlayInput.shared.toggleEditor(show: true)
             previousWindow = screen.keyWindow
             editorWindow = initWindow()
             editorWindow?.makeKeyAndVisible()

--- a/PlayTools/PlayScreen.swift
+++ b/PlayTools/PlayScreen.swift
@@ -20,7 +20,11 @@ extension CGSize {
     }
 
     func toAspectRatio() -> CGSize {
-        return CGSize(width: mainScreenHeight, height: mainScreenWidth)
+        if #available(macCatalyst 16.3, *) {
+            return CGSize(width: mainScreenWidth, height: mainScreenHeight)
+        } else {
+            return CGSize(width: mainScreenHeight, height: mainScreenWidth)
+        }
     }
 }
 
@@ -34,11 +38,11 @@ extension CGRect {
     }
 
     func toAspectRatio() -> CGRect {
-        return CGRect(x: minX, y: minY, width: mainScreenHeight, height: mainScreenWidth)
+        return CGRect(x: minX, y: minY, width: mainScreenWidth, height: mainScreenHeight)
     }
 
     func toAspectRatioReversed() -> CGRect {
-        return CGRect(x: minX, y: minY, width: mainScreenWidth, height: mainScreenHeight)
+        return CGRect(x: minX, y: minY, width: mainScreenHeight, height: mainScreenWidth)
     }
 }
 
@@ -65,11 +69,11 @@ public class PlayScreen: NSObject {
     @objc public static let shared = PlayScreen()
 
     @objc public static func frame(_ rect: CGRect) -> CGRect {
-        return rect.toAspectRatio()
+        return rect.toAspectRatioReversed()
     }
 
     @objc public static func bounds(_ rect: CGRect) -> CGRect {
-        return rect.toAspectRatioReversed()
+        return rect.toAspectRatio()
     }
 
     @objc public static func width(_ size: Int) -> Int {

--- a/Plugin.swift
+++ b/Plugin.swift
@@ -23,6 +23,7 @@ public protocol Plugin: NSObjectProtocol {
     func terminateApplication()
     func eliminateRedundantKeyPressEvents(_ dontIgnore: @escaping() -> Bool)
     func setupMouseButton(_ _up: Int, _ _down: Int, _ dontIgnore: @escaping(Int, Bool, Bool) -> Bool)
+    func setupScrollWheel(_ onMoved: @escaping(CGFloat, CGFloat) -> Bool)
     func urlForApplicationWithBundleIdentifier(_ value: String) -> URL?
     func setMenuBarVisible(_ value: Bool)
 }


### PR DESCRIPTION
Depends on #69 

This PR enhances camera control, so that mouse scroll wheel can be used to scale camera in and out.

Additionally, when cursor is shown, scroll wheel is mapped to drag the screen, so that scroll wheel can be used to scroll menus.