### PR TITLE
Refactor input handlers

### DIFF
--- a/PlayTools/Controls/PTFakeTouch/PTFakeMetaTouch.m
+++ b/PlayTools/Controls/PTFakeTouch/PTFakeMetaTouch.m
@@ -65,7 +65,7 @@ void eventSendCallback(void* info) {
         touch = toStationarify;
         toStationarify = NULL;
         if(touch.phase == UITouchPhaseBegan) {
-            [touch setPhaseAndUpdateTimestamp:UITouchPhaseStationary];
+            [touch setPhaseAndUpdateTimestamp:UITouchPhaseMoved];
         }
     }
     // respect the semantics of touch phase, allocate new touch on touch began.

--- a/PlayTools/Controls/PlayAction.swift
+++ b/PlayTools/Controls/PlayAction.swift
@@ -30,8 +30,10 @@ class ButtonAction: Action {
         self.keyCode = keyCode
         self.keyName = keyName
         self.point = point
+        let code = keyCode.rawValue
         // TODO: set both key names in draggable button, so as to depracate key code
-        PlayInput.registerButton(key: KeyCodeNames.keyCodes[keyCode.rawValue]!, handler: self.update)
+        PlayInput.registerButton(key: code == KeyCodeNames.defaultCode ? keyName: KeyCodeNames.keyCodes[code]!,
+                                 handler: self.update)
     }
 
     convenience init(data: Button) {
@@ -59,7 +61,6 @@ class DraggableButtonAction: ButtonAction {
     override init(keyCode: GCKeyCode, keyName: String, point: CGPoint) {
         self.releasePoint = point
         super.init(keyCode: keyCode, keyName: keyName, point: point)
-        _ = PlayMice.shared.setupThumbstickChangedHandler(name: keyName)
     }
 
     override func update(pressed: Bool) {
@@ -101,10 +102,10 @@ class ContinuousJoystickAction: Action {
         self.key = data.keyName
         position = center
         self.sensitivity = data.transform.size.absoluteSize / 4
-        if PlayMice.shared.setupThumbstickChangedHandler(name: key) {
-            PlayMice.shared.joystickHandler[key] = thumbstickUpdate
+        if key == PlayMice.elementName {
+            PlayMice.shared.joystickHandler[key] = self.mouseUpdate
         } else {
-            PlayMice.shared.joystickHandler[key] = mouseUpdate
+            PlayMice.shared.joystickHandler[key] = self.thumbstickUpdate
         }
     }
 
@@ -151,16 +152,8 @@ class JoystickAction: Action {
         self.keys = keys
         self.center = center
         self.shift = shift / 2
-        if let keyboard = GCKeyboard.coalesced?.keyboardInput {
-            for key in keys {
-                let handler = keyboard.button(forKeyCode: key)?.pressedChangedHandler
-                keyboard.button(forKeyCode: key)?.pressedChangedHandler = { button, value, pressed in
-                    Toucher.touchQueue.async(execute: self.update)
-                    if let previous = handler {
-                        previous(button, value, pressed)
-                    }
-                }
-            }
+        for key in keys {
+            PlayInput.registerButton(key: KeyCodeNames.keyCodes[key.rawValue]!, handler: self.update)
         }
     }
 
@@ -181,28 +174,19 @@ class JoystickAction: Action {
     func invalidate() {
         Toucher.touchcam(point: center, phase: UITouch.Phase.ended, tid: &id)
         self.moving = false
-        if let keyboard = GCKeyboard.coalesced?.keyboardInput {
-            for key in keys {
-                keyboard.button(forKeyCode: key)?.pressedChangedHandler = nil
-            }
-        }
     }
 
-    func update() {
-        if mode.visible {
-            return
-        }
+    func update(_: Bool) {
         var touch = center
-        var start = center
         if GCKeyboard.pressed(key: keys[0]) {
-            touch.y -= shift / 3
+            touch.y -= shift / 2
         } else if GCKeyboard.pressed(key: keys[1]) {
-            touch.y += shift / 3
+            touch.y += shift / 2
         }
         if GCKeyboard.pressed(key: keys[2]) {
-            touch.x -= shift / 3
+            touch.x -= shift / 2
         } else if GCKeyboard.pressed(key: keys[3]) {
-            touch.x += shift / 3
+            touch.x += shift / 2
         }
         if moving {
             if touch.equalTo(center) {
@@ -213,15 +197,8 @@ class JoystickAction: Action {
             }
         } else {
             if !touch.equalTo(center) {
-                start.x += (touch.x - start.x) / 8
-                start.y += (touch.y - start.y) / 8
                 moving = true
-                Toucher.touchcam(point: start, phase: UITouch.Phase.began, tid: &id)
-                Toucher.touchQueue.asyncAfter(deadline: .now() + 0.04) {
-                    if self.moving {
-                        Toucher.touchcam(point: touch, phase: UITouch.Phase.moved, tid: &self.id)
-                    } // end if
-                } // end closure
+                Toucher.touchcam(point: touch, phase: UITouch.Phase.began, tid: &id)
             } // end if
         } // end else
     }

--- a/PlayTools/Keymap/ControlModel.swift
+++ b/PlayTools/Keymap/ControlModel.swift
@@ -1,5 +1,7 @@
 import GameController
 
+// Data structure definition should match those in
+// https://github.com/PlayCover/PlayCover/blob/develop/PlayCover/Model/Keymapping.swift
 class ControlData {
     var keyCodes: [Int]
     var keyName: String

--- a/PlayTools/Keymap/KeyCodeNames.swift
+++ b/PlayTools/Keymap/KeyCodeNames.swift
@@ -1,3 +1,4 @@
+// Should match https://github.com/PlayCover/PlayCover/blob/develop/PlayCover/Model/KeyCodeNames.swift exactly
 class KeyCodeNames {
     public static let defaultCode = -10
 

--- a/PlayTools/Keymap/Keymapping.swift
+++ b/PlayTools/Keymap/Keymapping.swift
@@ -63,7 +63,8 @@ class Keymapping {
         }
     }
 }
-
+// Data structure definition should match those in
+// https://github.com/PlayCover/PlayCover/blob/develop/PlayCover/Model/Keymapping.swift
 struct KeyModelTransform: Codable {
     var size: CGFloat
     var xCoord: CGFloat


### PR DESCRIPTION
In the existing code, in the initialization of `action`s, event handlers are setup, so that this `action` can be executed whenever corresponding hardware input happens. While in `PlayInput` there are also event handler setups that serve purposes like keymap editor, it appears that there are multiple places setting up event handlers for the same input device.

This PR aims to construct a unified action registration mechanism, in which `action`s does not setup event handlers directly, but rather register their handlers to the _hardware abstraction layer_ (aka. `PlayInput` and `PlayMice`). The latter is responsible for dispatching hardware events to appropriate receivers.

This would make the code structure clearer and make it easier to add new features, like complete controller support.