### PR TITLE
fix: Prevent ObjC object dereferencing if debugging is not enabled

### DIFF
--- a/PlayTools/PlayLoader.m
+++ b/PlayTools/PlayLoader.m
@@ -103,8 +103,10 @@ static OSStatus pt_SecItemCopyMatching(CFDictionaryRef query, CFTypeRef *result)
         retval = SecItemCopyMatching(query, result);
     }
     if (result != NULL) {
-        [PlayKeychain debugLogger:[NSString stringWithFormat:@"SecItemCopyMatching: %@", query]];
-        [PlayKeychain debugLogger:[NSString stringWithFormat:@"SecItemCopyMatching result: %@", *result]];
+        if ([[PlaySettings shared] playChainDebugging]) {
+            [PlayKeychain debugLogger:[NSString stringWithFormat:@"SecItemCopyMatching: %@", query]];
+            [PlayKeychain debugLogger:[NSString stringWithFormat:@"SecItemCopyMatching result: %@", *result]];
+        }
     }
     return retval;
 }
@@ -117,8 +119,10 @@ static OSStatus pt_SecItemAdd(CFDictionaryRef attributes, CFTypeRef *result) {
         retval = SecItemAdd(attributes, result);
     }
     if (result != NULL) {
-        [PlayKeychain debugLogger: [NSString stringWithFormat:@"SecItemAdd: %@", attributes]];
-        [PlayKeychain debugLogger: [NSString stringWithFormat:@"SecItemAdd result: %@", *result]];
+        if ([[PlaySettings shared] playChainDebugging]) {
+            [PlayKeychain debugLogger: [NSString stringWithFormat:@"SecItemAdd: %@", attributes]];
+            [PlayKeychain debugLogger: [NSString stringWithFormat:@"SecItemAdd result: %@", *result]];
+        }
     }
     return retval;
 }
@@ -131,8 +135,10 @@ static OSStatus pt_SecItemUpdate(CFDictionaryRef query, CFDictionaryRef attribut
         retval = SecItemUpdate(query, attributesToUpdate);
     }
     if (attributesToUpdate != NULL) {
-        [PlayKeychain debugLogger: [NSString stringWithFormat:@"SecItemUpdate: %@", query]];
-        [PlayKeychain debugLogger: [NSString stringWithFormat:@"SecItemUpdate attributesToUpdate: %@", attributesToUpdate]];
+        if ([[PlaySettings shared] playChainDebugging]) {
+            [PlayKeychain debugLogger: [NSString stringWithFormat:@"SecItemUpdate: %@", query]];
+            [PlayKeychain debugLogger: [NSString stringWithFormat:@"SecItemUpdate attributesToUpdate: %@", attributesToUpdate]];
+        }
     }
     return retval;
 
@@ -145,7 +151,9 @@ static OSStatus pt_SecItemDelete(CFDictionaryRef query) {
     } else {
         retval = SecItemDelete(query);
     }
-    [PlayKeychain debugLogger: [NSString stringWithFormat:@"SecItemDelete: %@", query]];
+    if ([[PlaySettings shared] playChainDebugging]) {
+        [PlayKeychain debugLogger: [NSString stringWithFormat:@"SecItemDelete: %@", query]];
+    }
     return retval;
 }
 


### PR DESCRIPTION
While this is normally harmless, some apps (such as Amazon Kindle) do... strange things with their Keychain objects
This is tolerable for Keychain itself, but ABSOLUTELY NOT for ObjC and attempting to dereference them will lead to a crash because NSString can't format them