### PR TITLE
Fix wrong OEM IDs 

### DIFF
--- a/PlayTools/PlaySettings.swift
+++ b/PlayTools/PlaySettings.swift
@@ -45,16 +45,20 @@ let settings = PlaySettings.shared
         switch settingsData.iosDeviceModel {
         case "iPad6,7":
             return "J98aAP"
+        case "iPad7,1":
+            return "J120AP"
         case "iPad8,6":
             return "J320xAP"
+        case "iPad8,11":
+            return "J420AP"
         case "iPad13,8":
             return "J522AP"
         case "iPad14,5":
-            return "A2436"
+            return "J620AP"
         case "iPhone14,3":
-            return "A2645"
+            return "D64AP"
         case "iPhone15,3":
-            return "A2896"
+            return "D74AP"
         default:
             return "J320xAP"
         }

--- a/PlayTools/PlaySettings.swift
+++ b/PlayTools/PlaySettings.swift
@@ -45,12 +45,8 @@ let settings = PlaySettings.shared
         switch settingsData.iosDeviceModel {
         case "iPad6,7":
             return "J98aAP"
-        case "iPad7,1":
-            return "J120AP"
         case "iPad8,6":
             return "J320xAP"
-        case "iPad8,11":
-            return "J420AP"
         case "iPad13,8":
             return "J522AP"
         case "iPad14,5":


### PR DESCRIPTION
Fixed: 
- M2 iPad Pro
- iPhone 13 Pro Max
- iPhone 14 Pro Max

These had incorrect OEM IDs, the "A" numbers are in fact family numbers, not the proper internal board/hardware/OEM ID used to target software. For more info see this article on [Apple Device Identifiers](https://reincubate.com/support/deviceidentifier/apple-identifiers/#understanding-codes)

I used multiple sources to verify the accuracy of the IDs
M2 iPad Pro: [GeekBench](https://browser.geekbench.com/v5/cpu/20450186), [PhoneDB](https://phonedb.net/index.php?m=device&id=20871&c=apple_ipad_pro_12.9-inch_2022_6th_gen_a2436_wifi_2tb__apple_ipad_14,5), [iPhone Wiki](https://www.theiphonewiki.com/wiki/IPad_Pro_(12.9-inch)_(6th_generation))
13 Pro Max: [GeekBench](https://browser.geekbench.com/v5/cpu/10677798), [PhoneDB](https://phonedb.net/index.php?m=device&id=19094&c=apple_iphone_13_pro_max_5g_a2643_global_dual_sim_td-lte_1tb__apple_iphone_14,3), [iPhone WIki](https://www.theiphonewiki.com/wiki/D64AP)
14 Pro Max: [GeekBench](https://browser.geekbench.com/v5/compute/6376808), [PhoneDB](https://phonedb.net/index.php?m=device&id=20581&c=apple_iphone_14_pro_max_5g_a2894_global_dual_sim_td-lte_1tb__apple_iphone_15,3), [iPhone Wiki](https://www.theiphonewiki.com/wiki/D74AP)