### PR TITLE
fix: void out unavailable VSS calls

### DIFF
--- a/PlayTools/Controls/PTFakeTouch/NSObject+Swizzle.m
+++ b/PlayTools/Controls/PTFakeTouch/NSObject+Swizzle.m
@@ -11,6 +11,7 @@
 #import "UIKit/UIKit.h"
 #import <PlayTools/PlayTools-Swift.h>
 #import "PTFakeMetaTouch.h"
+#import <VideoSubscriberAccount/VideoSubscriberAccount.h>
 
 __attribute__((visibility("hidden")))
 @interface PTSwizzleLoader : NSObject
@@ -82,6 +83,10 @@ __attribute__((visibility("hidden")))
     return 2.0;
 }
 
+- (void) hook_setCurrentSubscription:(VSSubscription *)currentSubscription {
+    // do nothing
+}
+
 
 bool menuWasCreated = false;
 - (id) initWithRootMenuHook:(id)rootMenu {
@@ -136,6 +141,8 @@ bool menuWasCreated = false;
 
     [objc_getClass("_UIMenuBuilder") swizzleInstanceMethod:sel_getUid("initWithRootMenu:") withMethod:@selector(initWithRootMenuHook:)];
     [objc_getClass("IOSViewController") swizzleInstanceMethod:@selector(prefersPointerLocked) withMethod:@selector(hook_prefersPointerLocked)];
+
+    [objc_getClass("VSSubscriptionRegistrationCenter") swizzleInstanceMethod:@selector(setCurrentSubscription:) withMethod:@selector(hook_setCurrentSubscription:)];
 }
 
 @end


### PR DESCRIPTION
This patch fixes an issue where some video streaming apps may run for roughly half a second then quit unexpectedly