### PR TITLE
Hide the option to add a mouse controlled joystick in circle menu

### DIFF
--- a/PlayTools/Keymap/DragElementsView.swift
+++ b/PlayTools/Keymap/DragElementsView.swift
@@ -20,7 +20,7 @@ class KeymapHolder: CircleMenuDelegate {
             frame: CGRect(x: 0, y: 0, width: 50, height: 50),
             normalIcon: "xmark.circle.fill",
             selectedIcon: "xmark.circle.fill",
-            buttonsCount: 4,
+            buttonsCount: 3,
             duration: 0.25,
             distance: 80)
         menu?.delegate = self
@@ -57,7 +57,8 @@ class KeymapHolder: CircleMenuDelegate {
         case 2:
             EditorController.shared.addMouseArea(globalPoint!)
         default:
-            EditorController.shared.addMouseJoystick(globalPoint!)
+            Toast.showHint(title: "item \(atIndex) is not recognizable")
+//            EditorController.shared.addMouseJoystick(globalPoint!)
         }
         hideWithAnimation()
     }
@@ -73,7 +74,7 @@ class KeymapHolder: CircleMenuDelegate {
     private let items: [String] = [
           "circle.circle",
           "dpad",
-          "arrow.up.and.down.and.arrow.left.and.right",
+//          "arrow.up.and.down.and.arrow.left.and.right",
 //          "rb.rectangle.roundedbottom.fill",
 //          "lb.rectangle.roundedbottom",
           "computermouse"


### PR DESCRIPTION
Lots of people get confued between "rounded square mouse" and "circle mouse". Most of them actually needs "circle mouse", which is used to control camera. "rounded square mouse" is used to control movement. 

To avoid confusion to new comers, I removed the option to add a "rounded square mouse" in keymapping editor's circle menu.
<img width="172" alt="图片" src="https://user-images.githubusercontent.com/16048758/219865514-5cdeee95-b626-4c31-8992-565850514794.png">

For people who do need this, you can set a mouse controlled joystick by clicking any mouse button except left mouse button (i.e. right mouse button or middle mouse button) while focused on a WASD joystick. 

It would be better if we have text to describe what can be done to add a new mapping and to an existing mapping. I have researched a little and find it impossible under the current editor architecture. Either a refactor to the current editor or a complete new editor is needed to achieve this.

There is a known issue that mouse button does not work in editor without previously enabled keymapping. This issue is left unfixed in this PR to avoid conflict with other PRs.