### PR TITLE
Fully disables input mapping when typing

### DIFF
--- a/PlayTools/Controls/ControlMode.swift
+++ b/PlayTools/Controls/ControlMode.swift
@@ -22,27 +22,34 @@ public class ControlMode {
         return false
     }
 
+    func setMapping(_ mapped: Bool) {
+        keyboardMapped = mapped
+        if mapped {
+            PlayInput.shared.parseKeymap()
+        } else {
+            PlayInput.shared.invalidate()
+        }
+    }
+
     func show(_ show: Bool) {
         if !editor.editorMode {
             if show {
                 if !visible {
-                    NotificationCenter.default.post(name: NSNotification.Name.playtoolsKeymappingWillDisable,
+                    NotificationCenter.default.post(name: NSNotification.Name.playtoolsCursorWillShow,
                                                     object: nil, userInfo: [:])
                     if screen.fullscreen {
                         screen.switchDock(true)
                     }
                     AKInterface.shared!.unhideCursor()
-//                    PlayInput.shared.invalidate()
                 }
             } else {
                 if visible {
-                    NotificationCenter.default.post(name: NSNotification.Name.playtoolsKeymappingWillEnable,
+                    NotificationCenter.default.post(name: NSNotification.Name.playtoolsCursorWillHide,
                                                     object: nil, userInfo: [:])
                     AKInterface.shared!.hideCursor()
                     if screen.fullscreen {
                         screen.switchDock(false)
                     }
-//                    PlayInput.shared.setup()
                 }
             }
             Toucher.writeLog(logMessage: "cursor show switched to \(show)")
@@ -52,9 +59,9 @@ public class ControlMode {
 }
 
 extension NSNotification.Name {
-    public static let playtoolsKeymappingWillEnable: NSNotification.Name
-                    = NSNotification.Name("playtools.keymappingWillEnable")
+    public static let playtoolsCursorWillHide: NSNotification.Name
+                    = NSNotification.Name("playtools.cursorWillHide")
 
-    public static let playtoolsKeymappingWillDisable: NSNotification.Name
-                    = NSNotification.Name("playtools.keymappingWillDisable")
+    public static let playtoolsCursorWillShow: NSNotification.Name
+                    = NSNotification.Name("playtools.cursorWillShow")
 }

--- a/PlayTools/Controls/ControlMode.swift
+++ b/PlayTools/Controls/ControlMode.swift
@@ -23,16 +23,17 @@ public class ControlMode {
     }
 
     func setMapping(_ mapped: Bool) {
-        keyboardMapped = mapped
         if mapped {
             PlayInput.shared.parseKeymap()
         } else {
+            show(true)
             PlayInput.shared.invalidate()
         }
+        keyboardMapped = mapped
     }
 
     func show(_ show: Bool) {
-        if !editor.editorMode {
+        if keyboardMapped {
             if show {
                 if !visible {
                     NotificationCenter.default.post(name: NSNotification.Name.playtoolsCursorWillShow,

--- a/PlayTools/Controls/PlayInput.swift
+++ b/PlayTools/Controls/PlayInput.swift
@@ -32,9 +32,9 @@ class PlayInput {
     }
 
     func parseKeymap() {
-        actions = []
-        PlayInput.shouldLockCursor = false
+        actions = [PlayMice.shared]
         PlayInput.buttonHandlers.removeAll(keepingCapacity: true)
+        PlayInput.shouldLockCursor = false
         for button in keymap.keymapData.buttonModels {
             actions.append(ButtonAction(data: button))
         }
@@ -61,7 +61,7 @@ class PlayInput {
     }
 
     public func toggleEditor(show: Bool) {
-        mode.keyboardMapped = !show
+        mode.setMapping(!show)
         Toucher.writeLog(logMessage: "editor opened? \(show)")
         if show {
             self.invalidate()
@@ -156,11 +156,11 @@ class PlayKeyboard {
         let centre = NotificationCenter.default
         let main = OperationQueue.main
         centre.addObserver(forName: UIApplication.keyboardDidHideNotification, object: nil, queue: main) { _ in
-            mode.keyboardMapped = true
+            mode.setMapping(true)
             Toucher.writeLog(logMessage: "virtual keyboard did hide")
         }
         centre.addObserver(forName: UIApplication.keyboardWillShowNotification, object: nil, queue: main) { _ in
-            mode.keyboardMapped = false
+            mode.setMapping(false)
             Toucher.writeLog(logMessage: "virtual keyboard will show")
         }
         AKInterface.shared!.setupKeyboard(keyboard: {keycode, pressed, isRepeat in

--- a/PlayTools/Controls/PlayInput.swift
+++ b/PlayTools/Controls/PlayInput.swift
@@ -65,7 +65,6 @@ class PlayInput {
         Toucher.writeLog(logMessage: "editor opened? \(show)")
         if show {
             self.invalidate()
-            mode.show(show)
             if let keyboard = GCKeyboard.coalesced!.keyboardInput {
                 keyboard.keyChangedHandler = { _, _, keyCode, pressed in
                     PlayKeyboard.handleEditorEvent(keyCode: keyCode, pressed: pressed)

--- a/PlayTools/Controls/PlayMice.swift
+++ b/PlayTools/Controls/PlayMice.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class PlayMice {
+public class PlayMice: Action {
 
     public static let shared = PlayMice()
     public static let elementName = "Mouse"
@@ -139,6 +139,7 @@ public class PlayMice {
             }
             guard let curPos = self.cursorPos() else { return true }
             PlayInput.touchQueue.async(qos: .userInteractive, execute: {
+                // considering cases where cursor becomes hidden while holding left button
                 if self.fakedMousePressed {
                     Toucher.touchcam(point: curPos, phase: UITouch.Phase.ended, tid: &self.fakedMouseTouchPointId)
                     return
@@ -149,6 +150,7 @@ public class PlayMice {
                                      tid: &self.fakedMouseTouchPointId)
                     return
                 }
+                // considering cases where cursor becomes visible while holding left button
                 if let handlers = PlayInput.buttonHandlers["LMB"] {
                     for handler in handlers {
                         handler(pressed)
@@ -158,6 +160,11 @@ public class PlayMice {
             })
             return false
         }
+    }
+    // For all other actions, this is a destructor. should release held resources.
+    func invalidate() {
+        Toucher.touchcam(point: self.cursorPos() ?? CGPoint(x: 10, y: 10),
+                         phase: UITouch.Phase.ended, tid: &self.fakedMouseTouchPointId)
     }
 }
 

--- a/PlayTools/Keymap/EditorController.swift
+++ b/PlayTools/Keymap/EditorController.swift
@@ -74,7 +74,7 @@ class EditorController {
                                                     tableName: "Playtools",
                                 value: "Click a button to edit its position or key bind\n"
                                         + "Click an empty area to open input menu", comment: "")],
-                           notification: NSNotification.Name.playtoolsKeymappingWillEnable)
+                           notification: NSNotification.Name.playtoolsCursorWillHide)
         }
 //        Toast.showOver(msg: "\(UIApplication.shared.windows.count)")
         lock.unlock()

--- a/PlayTools/Utils/Toast.swift
+++ b/PlayTools/Utils/Toast.swift
@@ -123,7 +123,7 @@ class Toast {
         }
         var token2: NSObjectProtocol?
         let center = NotificationCenter.default
-        token2 = center.addObserver(forName: NSNotification.Name.playtoolsKeymappingWillDisable,
+        token2 = center.addObserver(forName: NSNotification.Name.playtoolsCursorWillShow,
                                     object: nil, queue: OperationQueue.main) { _ in
             center.removeObserver(token2!)
             UserDefaults.standard.set(thisUse, forKey: persistenceKeyname)
@@ -147,10 +147,10 @@ class Toast {
                                                 tableName: "Playtools",
                                                 value: "to enable mouse mapping", comment: "")],
                        timeout: 10,
-                       notification: NSNotification.Name.playtoolsKeymappingWillEnable)
+                       notification: NSNotification.Name.playtoolsCursorWillHide)
         let center = NotificationCenter.default
         var token: NSObjectProtocol?
-        token = center.addObserver(forName: NSNotification.Name.playtoolsKeymappingWillEnable,
+        token = center.addObserver(forName: NSNotification.Name.playtoolsCursorWillHide,
                                    object: nil, queue: OperationQueue.main) { _ in
             center.removeObserver(token!)
             Toast.showHint(title: NSLocalizedString("hint.showCursor.title",
@@ -164,7 +164,7 @@ class Toast {
                                                     tableName: "Playtools",
                                                     value: "to unlock cursor", comment: "")],
                            timeout: 10,
-                           notification: NSNotification.Name.playtoolsKeymappingWillDisable)
+                           notification: NSNotification.Name.playtoolsCursorWillShow)
         }
     }
     


### PR DESCRIPTION
Fix issues that if any mapped key is held while entering typing mode, the touch point would not release even if the key is released.

In the original design, only keyboard mapping is disabled when typing. 
This PR would also disable mouse and controller mapping, so that it could conveniently release all touch points.

Steps to reproduce the issue in Genshin:
1. Hold any key mapped but not on UI elements, say F
2. Click an input box to enter typing mode
3. Release F
4. Press Enter or Esc to exit typing mode
5. Hide cursor and move mouse. Now the expected behaviour is that camera moves, but the actual behaviour is that camera zooms.

Besides, this PR renames corresponding notification names from `KeymappingEnable/Disable` to `CursorHide/Show` to match the actual behaviour.