### PR TITLE
Fix draggable button associate mouse cursor

### DIFF
--- a/AKPlugin.swift
+++ b/AKPlugin.swift
@@ -38,9 +38,10 @@ class AKPlugin: NSObject, Plugin {
     }
 
     var cmdPressed: Bool = false
-
+    var cursorHideLevel = 0
     func hideCursor() {
         NSCursor.hide()
+        cursorHideLevel += 1
         CGAssociateMouseAndMouseCursorPosition(0)
         warpCursor()
     }
@@ -54,7 +55,10 @@ class AKPlugin: NSObject, Plugin {
 
     func unhideCursor() {
         NSCursor.unhide()
-        CGAssociateMouseAndMouseCursorPosition(1)
+        cursorHideLevel -= 1
+        if cursorHideLevel <= 0 {
+            CGAssociateMouseAndMouseCursorPosition(1)
+        }
     }
 
     func terminateApplication() {


### PR DESCRIPTION
Fixes the issue that draggable button could unexpectedly associate mouse and cursor when cursor is hidden.

Steps to reproduce:
1. Bind some key to draggable button, say E
2. Hide cursor
3. Press E and release it
4. Move mouse
5. Unhide cursor. The expected behavior is that the cursor appears at center. The actual behavior is that the cursor could appear somewhere else.