### PR TITLE
fix: auto keyboard toggle

### DIFF
--- a/PlayTools/Controls/ControlMode.swift
+++ b/PlayTools/Controls/ControlMode.swift
@@ -55,7 +55,7 @@ public class ControlMode {
             }
             Toucher.writeLog(logMessage: "cursor show switched to \(show)")
             visible = show
-            if PlaySettings.shared.noKMOnInput {
+            if !PlaySettings.shared.noKMOnInput {
                 keyboardMapped = false
             }
         }

--- a/PlayTools/Controls/ControlMode.swift
+++ b/PlayTools/Controls/ControlMode.swift
@@ -47,6 +47,9 @@ public class ControlMode {
             }
             Toucher.writeLog(logMessage: "cursor show switched to \(show)")
             visible = show
+            if PlaySettings.shared.noKMOnInput {
+                keyboardMapped = false
+            }
         }
     }
 }

--- a/PlayTools/Controls/PlayInput.swift
+++ b/PlayTools/Controls/PlayInput.swift
@@ -154,13 +154,15 @@ class PlayKeyboard {
     public static func initialize() {
         let centre = NotificationCenter.default
         let main = OperationQueue.main
-        centre.addObserver(forName: UIApplication.keyboardDidHideNotification, object: nil, queue: main) { _ in
-            mode.setMapping(true)
-            Toucher.writeLog(logMessage: "virtual keyboard did hide")
-        }
-        centre.addObserver(forName: UIApplication.keyboardWillShowNotification, object: nil, queue: main) { _ in
-            mode.setMapping(false)
-            Toucher.writeLog(logMessage: "virtual keyboard will show")
+        if PlaySettings.shared.noKMOnInput {
+            centre.addObserver(forName: UIApplication.keyboardDidHideNotification, object: nil, queue: main) { _ in
+                mode.setMapping(true)
+                Toucher.writeLog(logMessage: "virtual keyboard did hide")
+            }
+            centre.addObserver(forName: UIApplication.keyboardWillShowNotification, object: nil, queue: main) { _ in
+                mode.setMapping(false)
+                Toucher.writeLog(logMessage: "virtual keyboard will show")
+            }
         }
         AKInterface.shared!.setupKeyboard(keyboard: {keycode, pressed, isRepeat in
             if !mode.keyboardMapped {

--- a/PlayTools/Controls/PlayInput.swift
+++ b/PlayTools/Controls/PlayInput.swift
@@ -155,13 +155,17 @@ class PlayKeyboard {
     public static func initialize() {
         let centre = NotificationCenter.default
         let main = OperationQueue.main
-        centre.addObserver(forName: UIApplication.keyboardDidHideNotification, object: nil, queue: main) { _ in
-            mode.keyboardMapped = true
-            Toucher.writeLog(logMessage: "virtual keyboard did hide")
-        }
-        centre.addObserver(forName: UIApplication.keyboardWillShowNotification, object: nil, queue: main) { _ in
-            mode.keyboardMapped = false
-            Toucher.writeLog(logMessage: "virtual keyboard will show")
+        
+        // Initialize observers to automatically hide keymappings
+        if PlaySettings.shared.noKMOnInput {
+            centre.addObserver(forName: UIApplication.keyboardDidHideNotification, object: nil, queue: main) { _ in
+                mode.keyboardMapped = true
+                Toucher.writeLog(logMessage: "virtual keyboard did hide")
+            }
+            centre.addObserver(forName: UIApplication.keyboardWillShowNotification, object: nil, queue: main) { _ in
+                mode.keyboardMapped = false
+                Toucher.writeLog(logMessage: "virtual keyboard will show")
+            }
         }
         AKInterface.shared!.setupKeyboard(keyboard: {keycode, pressed, isRepeat in
             if !mode.keyboardMapped {

--- a/PlayTools/Controls/Toucher.swift
+++ b/PlayTools/Controls/Toucher.swift
@@ -10,7 +10,7 @@ class Toucher {
     static weak var keyWindow: UIWindow?
     static weak var keyView: UIView?
     // For debug only
-    static var logEnabled = false
+    static var logEnabled = true
     static var logFilePath =
     NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true)[0] + "/toucher.log"
     static private var logCount = 0

--- a/PlayTools/Controls/Toucher.swift
+++ b/PlayTools/Controls/Toucher.swift
@@ -10,7 +10,7 @@ class Toucher {
     static weak var keyWindow: UIWindow?
     static weak var keyView: UIView?
     // For debug only
-    static var logEnabled = true
+    static var logEnabled = false
     static var logFilePath =
     NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true)[0] + "/toucher.log"
     static private var logCount = 0

--- a/PlayTools/PlaySettings.swift
+++ b/PlayTools/PlaySettings.swift
@@ -71,6 +71,8 @@ let settings = PlaySettings.shared
     @objc lazy var customScaler = settingsData.customScaler
     
     @objc lazy var rootWorkDir = settingsData.rootWorkDir
+    
+    @objc lazy var noKMOnInput = settingsData.noKMOnInput
 }
 
 struct AppSettingsData: Codable {
@@ -93,4 +95,5 @@ struct AppSettingsData: Codable {
     var inverseScreenValues = false
     var windowFixMethod = 0
     var rootWorkDir = true
+    var noKMOnInput = false
 }

--- a/PlayTools/Utils/Toast.swift
+++ b/PlayTools/Utils/Toast.swift
@@ -83,6 +83,10 @@ class Toast {
         messageLabel.center.x = parent.center.x
         messageLabel.center.y = -messageLabel.frame.size.height / 2
 
+        // Disable editing
+        messageLabel.isEditable = false
+        messageLabel.isSelectable = false
+
         hintView.append(messageLabel)
         parent.addSubview(messageLabel)
 


### PR DESCRIPTION
Add an option to disable the newly introduced automatic keymapping toggle.

The issue being that some games don't correctly emit keyboard event and can cause weird behaviours when relied on