### PR TITLE
fix: temporarily disable extra jb bypass for release

### DIFF
--- a/PlayTools/MysticRunes/PlayShadow.m
+++ b/PlayTools/MysticRunes/PlayShadow.m
@@ -159,7 +159,10 @@ __attribute__((visibility("hidden")))
 
 + (void) load {
     [self debugLogger:@"PlayShadow is now loading"];
-    if ([[PlaySettings shared] bypass]) [self loadJailbreakBypass];
+    // Gate this behind an environment variable
+    if ([[NSProcessInfo processInfo].environment[@"USE_EXTRA_ANTIJB"] isEqualToString:@"1"]) {
+        [self loadJailbreakBypass];
+    }
     // if ([[PlaySettings shared] bypass]) [self loadEnvironmentBypass]; # disabled as it might be too powerful
 
     // Swizzle ATTrackingManager


### PR DESCRIPTION
Temporarily gate this behind an envvar so it can't be enable from UI
Reportedly this is breaking Japan BA. I'll implement one with fishhook later