### PR TITLE
Patch for Sonoma14.1 betas

### DIFF
--- a/PlayTools/Controls/PTFakeTouch/NSObject+Swizzle.m
+++ b/PlayTools/Controls/PTFakeTouch/NSObject+Swizzle.m
@@ -50,6 +50,16 @@ __attribute__((visibility("hidden")))
     }
 }
 
+- (void) swizzleExchangeMethod:(SEL)origSelector withMethod:(SEL)newSelector
+{
+    Class cls = [self class];
+    // If current class doesn't exist selector, then get super
+    Method originalMethod = class_getInstanceMethod(cls, origSelector);
+    Method swizzledMethod = class_getInstanceMethod(cls, newSelector);
+    
+    method_exchangeImplementations(originalMethod, swizzledMethod);
+}
+
 - (BOOL) hook_prefersPointerLocked {
     return false;
 }
@@ -112,10 +122,6 @@ __attribute__((visibility("hidden")))
     
 }
 
-- (void) hook_setCurrentSubscription:(VSSubscription *)currentSubscription {
-    // do nothing
-}
-
 // Hook for UIUserInterfaceIdiom
 
 // - (long long) hook_userInterfaceIdiom {
@@ -167,7 +173,8 @@ bool menuWasCreated = false;
             // This is an experimental fix
             if ([[PlaySettings shared] inverseScreenValues]) {
                 // This lines set External Scene settings and other IOS10 Runtime services by swizzling
-                [objc_getClass("FBSSceneSettings") swizzleInstanceMethod:@selector(frame) withMethod:@selector(hook_frameDefault)];
+                // In Sonoma 14.1 betas, frame method seems to be moved to FBSSceneSettingsCore
+                [objc_getClass("FBSSceneSettingsCore") swizzleExchangeMethod:@selector(frame) withMethod:@selector(hook_frameDefault)];
                 [objc_getClass("FBSSceneSettings") swizzleInstanceMethod:@selector(bounds) withMethod:@selector(hook_boundsDefault)];
                 [objc_getClass("FBSDisplayMode") swizzleInstanceMethod:@selector(size) withMethod:@selector(hook_sizeDelfault)];
                 
@@ -178,7 +185,7 @@ bool menuWasCreated = false;
                 [objc_getClass("UIScreen") swizzleInstanceMethod:@selector(scale) withMethod:@selector(hook_scale)];
             } else {
                 // This acutally runs when adaptiveDisplay is normally triggered
-                [objc_getClass("FBSSceneSettings") swizzleInstanceMethod:@selector(frame) withMethod:@selector(hook_frame)];
+                [objc_getClass("FBSSceneSettingsCore") swizzleExchangeMethod:@selector(frame) withMethod:@selector(hook_frame)];
                 [objc_getClass("FBSSceneSettings") swizzleInstanceMethod:@selector(bounds) withMethod:@selector(hook_bounds)];
                 [objc_getClass("FBSDisplayMode") swizzleInstanceMethod:@selector(size) withMethod:@selector(hook_size)];
                 
@@ -199,7 +206,7 @@ bool menuWasCreated = false;
                 CGFloat newValueH = (CGFloat)[self get_default_height];
                 [[PlaySettings shared] setValue:@(newValueH) forKey:@"windowSizeHeight"];
                 if (![[PlaySettings shared] inverseScreenValues]) {
-                    [objc_getClass("FBSSceneSettings") swizzleInstanceMethod:@selector(frame) withMethod:@selector(hook_frameDefault)];
+                    [objc_getClass("FBSSceneSettingsCore") swizzleExchangeMethod:@selector(frame) withMethod:@selector(hook_frameDefault)];
                     [objc_getClass("FBSSceneSettings") swizzleInstanceMethod:@selector(bounds) withMethod:@selector(hook_boundsDefault)];
                     [objc_getClass("FBSDisplayMode") swizzleInstanceMethod:@selector(size) withMethod:@selector(hook_sizeDelfault)];
                 }
@@ -213,7 +220,7 @@ bool menuWasCreated = false;
     } 
     else {
         if ([[PlaySettings shared] adaptiveDisplay]) {
-                [objc_getClass("FBSSceneSettings") swizzleInstanceMethod:@selector(frame) withMethod:@selector(hook_frame)];
+                [objc_getClass("FBSSceneSettingsCore") swizzleExchangeMethod:@selector(frame) withMethod:@selector(hook_frame)];
                 [objc_getClass("FBSSceneSettings") swizzleInstanceMethod:@selector(bounds) withMethod:@selector(hook_bounds)];
                 [objc_getClass("FBSDisplayMode") swizzleInstanceMethod:@selector(size) withMethod:@selector(hook_size)];
             }
@@ -224,8 +231,6 @@ bool menuWasCreated = false;
     // Set idiom to iPad
     // [objc_getClass("UIDevice") swizzleInstanceMethod:@selector(userInterfaceIdiom) withMethod:@selector(hook_userInterfaceIdiom)];
     // [objc_getClass("UITraitCollection") swizzleInstanceMethod:@selector(userInterfaceIdiom) withMethod:@selector(hook_userInterfaceIdiom)];
-
-    [objc_getClass("VSSubscriptionRegistrationCenter") swizzleInstanceMethod:@selector(setCurrentSubscription:) withMethod:@selector(hook_setCurrentSubscription:)];
 }
 
 @end

--- a/PlayTools/Controls/PTFakeTouch/NSObject+Swizzle.m
+++ b/PlayTools/Controls/PTFakeTouch/NSObject+Swizzle.m
@@ -247,7 +247,7 @@ bool menuWasCreated = false;
     // Set idiom to iPad
     // [objc_getClass("UIDevice") swizzleInstanceMethod:@selector(userInterfaceIdiom) withMethod:@selector(hook_userInterfaceIdiom)];
     // [objc_getClass("UITraitCollection") swizzleInstanceMethod:@selector(userInterfaceIdiom) withMethod:@selector(hook_userInterfaceIdiom)];
-    
+
     [objc_getClass("VSSubscriptionRegistrationCenter") swizzleInstanceMethod:@selector(setCurrentSubscription:) withMethod:@selector(hook_setCurrentSubscription:)];
 }
 

--- a/PlayTools/Controls/PTFakeTouch/NSObject+Swizzle.m
+++ b/PlayTools/Controls/PTFakeTouch/NSObject+Swizzle.m
@@ -174,7 +174,10 @@ bool menuWasCreated = false;
             if ([[PlaySettings shared] inverseScreenValues]) {
                 // This lines set External Scene settings and other IOS10 Runtime services by swizzling
                 // In Sonoma 14.1 betas, frame method seems to be moved to FBSSceneSettingsCore
-                [objc_getClass("FBSSceneSettingsCore") swizzleExchangeMethod:@selector(frame) withMethod:@selector(hook_frameDefault)];
+                if(@available(iOS 17.0.1, *))
+                    [objc_getClass("FBSSceneSettingsCore") swizzleExchangeMethod:@selector(frame) withMethod:@selector(hook_frameDefault)];
+                else
+                    [objc_getClass("FBSSceneSettings") swizzleInstanceMethod:@selector(frame) withMethod:@selector(hook_frameDefault)];
                 [objc_getClass("FBSSceneSettings") swizzleInstanceMethod:@selector(bounds) withMethod:@selector(hook_boundsDefault)];
                 [objc_getClass("FBSDisplayMode") swizzleInstanceMethod:@selector(size) withMethod:@selector(hook_sizeDelfault)];
                 
@@ -185,7 +188,10 @@ bool menuWasCreated = false;
                 [objc_getClass("UIScreen") swizzleInstanceMethod:@selector(scale) withMethod:@selector(hook_scale)];
             } else {
                 // This acutally runs when adaptiveDisplay is normally triggered
-                [objc_getClass("FBSSceneSettingsCore") swizzleExchangeMethod:@selector(frame) withMethod:@selector(hook_frame)];
+                if(@available(iOS 17.0.1, *))
+                    [objc_getClass("FBSSceneSettingsCore") swizzleExchangeMethod:@selector(frame) withMethod:@selector(hook_frame)];
+                else
+                    [objc_getClass("FBSSceneSettings") swizzleInstanceMethod:@selector(frame) withMethod:@selector(hook_frame)];
                 [objc_getClass("FBSSceneSettings") swizzleInstanceMethod:@selector(bounds) withMethod:@selector(hook_bounds)];
                 [objc_getClass("FBSDisplayMode") swizzleInstanceMethod:@selector(size) withMethod:@selector(hook_size)];
                 
@@ -206,7 +212,10 @@ bool menuWasCreated = false;
                 CGFloat newValueH = (CGFloat)[self get_default_height];
                 [[PlaySettings shared] setValue:@(newValueH) forKey:@"windowSizeHeight"];
                 if (![[PlaySettings shared] inverseScreenValues]) {
-                    [objc_getClass("FBSSceneSettingsCore") swizzleExchangeMethod:@selector(frame) withMethod:@selector(hook_frameDefault)];
+                    if(@available(iOS 17.0.1, *))
+                        [objc_getClass("FBSSceneSettingsCore") swizzleExchangeMethod:@selector(frame) withMethod:@selector(hook_frameDefault)];
+                    else
+                        [objc_getClass("FBSSceneSettings") swizzleInstanceMethod:@selector(frame) withMethod:@selector(hook_frameDefault)];
                     [objc_getClass("FBSSceneSettings") swizzleInstanceMethod:@selector(bounds) withMethod:@selector(hook_boundsDefault)];
                     [objc_getClass("FBSDisplayMode") swizzleInstanceMethod:@selector(size) withMethod:@selector(hook_sizeDelfault)];
                 }
@@ -220,7 +229,10 @@ bool menuWasCreated = false;
     } 
     else {
         if ([[PlaySettings shared] adaptiveDisplay]) {
-                [objc_getClass("FBSSceneSettingsCore") swizzleExchangeMethod:@selector(frame) withMethod:@selector(hook_frame)];
+                if(@available(iOS 17.0.1, *))
+                    [objc_getClass("FBSSceneSettingsCore") swizzleExchangeMethod:@selector(frame) withMethod:@selector(hook_frame)];
+                else
+                    [objc_getClass("FBSSceneSettingsCore") swizzleInstanceMethod:@selector(frame) withMethod:@selector(hook_frame)];
                 [objc_getClass("FBSSceneSettings") swizzleInstanceMethod:@selector(bounds) withMethod:@selector(hook_bounds)];
                 [objc_getClass("FBSDisplayMode") swizzleInstanceMethod:@selector(size) withMethod:@selector(hook_size)];
             }

--- a/PlayTools/Controls/PTFakeTouch/NSObject+Swizzle.m
+++ b/PlayTools/Controls/PTFakeTouch/NSObject+Swizzle.m
@@ -174,7 +174,7 @@ bool menuWasCreated = false;
             if ([[PlaySettings shared] inverseScreenValues]) {
                 // This lines set External Scene settings and other IOS10 Runtime services by swizzling
                 // In Sonoma 14.1 betas, frame method seems to be moved to FBSSceneSettingsCore
-                if(@available(iOS 17.0.1, *))
+                if(@available(iOS 17.1, *))
                     [objc_getClass("FBSSceneSettingsCore") swizzleExchangeMethod:@selector(frame) withMethod:@selector(hook_frameDefault)];
                 else
                     [objc_getClass("FBSSceneSettings") swizzleInstanceMethod:@selector(frame) withMethod:@selector(hook_frameDefault)];
@@ -188,7 +188,7 @@ bool menuWasCreated = false;
                 [objc_getClass("UIScreen") swizzleInstanceMethod:@selector(scale) withMethod:@selector(hook_scale)];
             } else {
                 // This acutally runs when adaptiveDisplay is normally triggered
-                if(@available(iOS 17.0.1, *))
+                if(@available(iOS 17.1, *))
                     [objc_getClass("FBSSceneSettingsCore") swizzleExchangeMethod:@selector(frame) withMethod:@selector(hook_frame)];
                 else
                     [objc_getClass("FBSSceneSettings") swizzleInstanceMethod:@selector(frame) withMethod:@selector(hook_frame)];
@@ -212,7 +212,7 @@ bool menuWasCreated = false;
                 CGFloat newValueH = (CGFloat)[self get_default_height];
                 [[PlaySettings shared] setValue:@(newValueH) forKey:@"windowSizeHeight"];
                 if (![[PlaySettings shared] inverseScreenValues]) {
-                    if(@available(iOS 17.0.1, *))
+                    if(@available(iOS 17.1, *))
                         [objc_getClass("FBSSceneSettingsCore") swizzleExchangeMethod:@selector(frame) withMethod:@selector(hook_frameDefault)];
                     else
                         [objc_getClass("FBSSceneSettings") swizzleInstanceMethod:@selector(frame) withMethod:@selector(hook_frameDefault)];
@@ -229,7 +229,7 @@ bool menuWasCreated = false;
     } 
     else {
         if ([[PlaySettings shared] adaptiveDisplay]) {
-                if(@available(iOS 17.0.1, *))
+                if(@available(iOS 17.1, *))
                     [objc_getClass("FBSSceneSettingsCore") swizzleExchangeMethod:@selector(frame) withMethod:@selector(hook_frame)];
                 else
                     [objc_getClass("FBSSceneSettings") swizzleInstanceMethod:@selector(frame) withMethod:@selector(hook_frame)];

--- a/PlayTools/Controls/PTFakeTouch/NSObject+Swizzle.m
+++ b/PlayTools/Controls/PTFakeTouch/NSObject+Swizzle.m
@@ -232,7 +232,7 @@ bool menuWasCreated = false;
                 if(@available(iOS 17.0.1, *))
                     [objc_getClass("FBSSceneSettingsCore") swizzleExchangeMethod:@selector(frame) withMethod:@selector(hook_frame)];
                 else
-                    [objc_getClass("FBSSceneSettingsCore") swizzleInstanceMethod:@selector(frame) withMethod:@selector(hook_frame)];
+                    [objc_getClass("FBSSceneSettings") swizzleInstanceMethod:@selector(frame) withMethod:@selector(hook_frame)];
                 [objc_getClass("FBSSceneSettings") swizzleInstanceMethod:@selector(bounds) withMethod:@selector(hook_bounds)];
                 [objc_getClass("FBSDisplayMode") swizzleInstanceMethod:@selector(size) withMethod:@selector(hook_size)];
             }

--- a/PlayTools/Controls/PTFakeTouch/NSObject+Swizzle.m
+++ b/PlayTools/Controls/PTFakeTouch/NSObject+Swizzle.m
@@ -122,6 +122,10 @@ __attribute__((visibility("hidden")))
     
 }
 
+- (void) hook_setCurrentSubscription:(VSSubscription *)currentSubscription {
+    // do nothing
+}
+
 // Hook for UIUserInterfaceIdiom
 
 // - (long long) hook_userInterfaceIdiom {
@@ -243,6 +247,8 @@ bool menuWasCreated = false;
     // Set idiom to iPad
     // [objc_getClass("UIDevice") swizzleInstanceMethod:@selector(userInterfaceIdiom) withMethod:@selector(hook_userInterfaceIdiom)];
     // [objc_getClass("UITraitCollection") swizzleInstanceMethod:@selector(userInterfaceIdiom) withMethod:@selector(hook_userInterfaceIdiom)];
+    
+    [objc_getClass("VSSubscriptionRegistrationCenter") swizzleInstanceMethod:@selector(setCurrentSubscription:) withMethod:@selector(hook_setCurrentSubscription:)];
 }
 
 @end


### PR DESCRIPTION
In Sonoma14.1 betas, FBSSceneSettings seems to have ```- (CGRect) frame```, FBSSceneSettingsCore does.
It can be swizzled by using ```exchangeMethod```. 
These code needs to be edited for Sonoma under 14.1betas.