### PR TITLE
Fix minor keymap bugs

### DIFF
--- a/PlayTools/Controls/Backend/Action/PlayAction.swift
+++ b/PlayTools/Controls/Backend/Action/PlayAction.swift
@@ -320,6 +320,10 @@ class SwipeAction: Action {
         timer.suspend()
     }
 
+    deinit {
+        timer.cancel()
+    }
+
     func delay(_ delay: Double, closure: @escaping () -> Void) {
         let when = DispatchTime.now() + delay
         PlayInput.touchQueue.asyncAfter(deadline: when, execute: closure)
@@ -372,7 +376,7 @@ class SwipeAction: Action {
     }
 
     func invalidate() {
-        timer.cancel()
+        timer.suspend()
         self.doLiftOff()
     }
 }

--- a/PlayTools/Controls/Frontend/ControlMode.swift
+++ b/PlayTools/Controls/Frontend/ControlMode.swift
@@ -91,13 +91,18 @@ public class ControlMode: Equatable {
 //            Toast.showHint(title: "should hide cursor? \(mouseAdapter.cursorHidden())",
 //                       text: ["current state: " + mode])
         }
-        if mouseAdapter.cursorHidden() != wasHidden {
+        if mouseAdapter.cursorHidden() != wasHidden && settings.keymapping {
             if wasHidden {
                 NotificationCenter.default.post(name: NSNotification.Name.playtoolsCursorWillShow,
                                                 object: nil, userInfo: [:])
                 if screen.fullscreen {
                     screen.switchDock(true)
                 }
+
+                if mode == .OFF || mode == .EDITOR {
+                    ActionDispatcher.invalidateActions()
+                }
+
                 AKInterface.shared!.unhideCursor()
             } else {
                 NotificationCenter.default.post(name: NSNotification.Name.playtoolsCursorWillHide,

--- a/PlayTools/Controls/Frontend/ModeAutomaton.swift
+++ b/PlayTools/Controls/Frontend/ModeAutomaton.swift
@@ -32,6 +32,10 @@ public class ModeAutomaton {
     }
 
     static public func onCmdK() {
+        guard settings.keymapping else {
+            return
+        }
+
         EditorController.shared.switchMode()
 
         if mode == .EDITOR && !EditorController.shared.editorMode {


### PR DESCRIPTION
Fixes:
- Allowing keymap editor when keymaps are disabled (which fixes bug where user can't exit hidden cursor after closing editor)
- Buttons still being pressed after releasing cursor or opening keymap editor (such as pressing "w" for forward and then releasing cursor which causes the button to still be pressed). The actions should only be invalidated if smart keymap is disabled.
- Swipe action crashing after invalidation, but not deinitialized (caused by the fix above). After cancelling a timer, it cannot be resumed, so that is moved to the `deinit` function.