### PR TITLE
Fix "rotate display" menu action for some apps disabled issue

### DIFF
--- a/PlayTools/Controls/MenuController.swift
+++ b/PlayTools/Controls/MenuController.swift
@@ -51,6 +51,19 @@ extension UIApplication {
         Toucher.writeLog(logMessage: "mark")
         Toast.showHint(title: "Log marked")
     }
+
+    @objc
+    func rotateView(_ sender: AnyObject) {
+        Toast.showHint(title: "Rotate")
+        
+        for scene in connectedScenes {
+            guard let windowScene = scene as? UIWindowScene else { continue }
+            for window in windowScene.windows {
+                guard let rootViewController = window.rootViewController else { continue }
+                rootViewController.rotateView(sender)
+            }
+        }
+    }
 }
 
 extension UIViewController {
@@ -85,7 +98,7 @@ var keymappingSelectors = [#selector(UIApplication.switchEditorMode(_:)),
                            #selector(UIApplication.removeElement(_:)),
                            #selector(UIApplication.upscaleElement(_:)),
                            #selector(UIApplication.downscaleElement(_:)),
-                           #selector(UIViewController.rotateView(_:))
+                           #selector(UIApplication.rotateView(_:))
     ]
 
 class MenuController {

--- a/PlayTools/Controls/MenuController.swift
+++ b/PlayTools/Controls/MenuController.swift
@@ -54,8 +54,6 @@ extension UIApplication {
 
     @objc
     func rotateView(_ sender: AnyObject) {
-        Toast.showHint(title: "Rotate")
-        
         for scene in connectedScenes {
             guard let windowScene = scene as? UIWindowScene else { continue }
             for window in windowScene.windows {
@@ -63,6 +61,10 @@ extension UIApplication {
                 rootViewController.rotateView(sender)
             }
         }
+        
+        DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 2, execute: {
+            Toast.showHint(title: "Rotated")
+        })
     }
 }
 


### PR DESCRIPTION
The key mapping "rotate display" command disabled in the some games/apps. This patch executes the rotate command on `UIApplication` and find all the connected `UIWindow`. Then trigger the old `rotateView` method on root view controller.

Before:
<img width="258" alt="image" src="https://github.com/PlayCover/PlayTools/assets/7940186/4ff4f9e1-ad86-4459-9e01-ac5e5509f681">

After:
<img width="290" alt="image" src="https://github.com/PlayCover/PlayTools/assets/7940186/371cdfa3-124b-4d3a-aa4b-c92167567d23">
