### PR TITLE
Fix smart keymapping disallowing textfield typing

### DIFF
--- a/PlayTools/Controls/Frontend/ControlMode.swift
+++ b/PlayTools/Controls/Frontend/ControlMode.swift
@@ -34,13 +34,13 @@ public class ControlMode: Equatable {
         let centre = NotificationCenter.default
         let main = OperationQueue.main
         if PlaySettings.shared.noKMOnInput {
-            centre.addObserver(forName: UIApplication.keyboardDidHideNotification, object: nil, queue: main) { _ in
-                ModeAutomaton.onKeyboardHide()
-                Toucher.writeLog(logMessage: "virtual keyboard did hide")
+            centre.addObserver(forName: UITextField.textDidEndEditingNotification, object: nil, queue: main) { _ in
+                ModeAutomaton.onTextFieldFinish()
+                Toucher.writeLog(logMessage: "textfield end edit")
             }
-            centre.addObserver(forName: UIApplication.keyboardWillShowNotification, object: nil, queue: main) { _ in
-                ModeAutomaton.onKeyboardShow()
-                Toucher.writeLog(logMessage: "virtual keyboard will show")
+            centre.addObserver(forName: UITextField.textDidBeginEditingNotification, object: nil, queue: main) { _ in
+                ModeAutomaton.onTextFieldEdit()
+                Toucher.writeLog(logMessage: "textfield begin edit")
             }
             set(.ARBITRARY_CLICK)
         } else {

--- a/PlayTools/Controls/Frontend/ControlMode.swift
+++ b/PlayTools/Controls/Frontend/ControlMode.swift
@@ -35,12 +35,20 @@ public class ControlMode: Equatable {
         let main = OperationQueue.main
         if PlaySettings.shared.noKMOnInput {
             centre.addObserver(forName: UITextField.textDidEndEditingNotification, object: nil, queue: main) { _ in
-                ModeAutomaton.onTextFieldFinish()
-                Toucher.writeLog(logMessage: "textfield end edit")
+                ModeAutomaton.onUITextInputEndEdit()
+                Toucher.writeLog(logMessage: "uitextinput end edit")
             }
             centre.addObserver(forName: UITextField.textDidBeginEditingNotification, object: nil, queue: main) { _ in
-                ModeAutomaton.onTextFieldEdit()
-                Toucher.writeLog(logMessage: "textfield begin edit")
+                ModeAutomaton.onUITextInputBeginEdit()
+                Toucher.writeLog(logMessage: "uitextinput begin edit")
+            }
+            centre.addObserver(forName: UITextView.textDidEndEditingNotification, object: nil, queue: main) { _ in
+                ModeAutomaton.onUITextInputEndEdit()
+                Toucher.writeLog(logMessage: "uitextinput end edit")
+            }
+            centre.addObserver(forName: UITextView.textDidBeginEditingNotification, object: nil, queue: main) { _ in
+                ModeAutomaton.onUITextInputBeginEdit()
+                Toucher.writeLog(logMessage: "uitextinput begin edit")
             }
             set(.ARBITRARY_CLICK)
         } else {

--- a/PlayTools/Controls/Frontend/ModeAutomaton.swift
+++ b/PlayTools/Controls/Frontend/ModeAutomaton.swift
@@ -48,14 +48,14 @@ public class ModeAutomaton {
         }
     }
 
-    static public func onKeyboardShow() {
+    static public func onTextFieldEdit() {
         if mode == .EDITOR {
             return
         }
         mode.set(.TEXT_INPUT)
     }
 
-    static public func onKeyboardHide() {
+    static public func onTextFieldFinish() {
         if mode == .EDITOR {
             return
         }

--- a/PlayTools/Controls/Frontend/ModeAutomaton.swift
+++ b/PlayTools/Controls/Frontend/ModeAutomaton.swift
@@ -48,14 +48,14 @@ public class ModeAutomaton {
         }
     }
 
-    static public func onTextFieldEdit() {
+    static public func onUITextInputBeginEdit() {
         if mode == .EDITOR {
             return
         }
         mode.set(.TEXT_INPUT)
     }
 
-    static public func onTextFieldFinish() {
+    static public func onUITextInputEndEdit() {
         if mode == .EDITOR {
             return
         }


### PR DESCRIPTION
Fixes bug where smart keymapping makes it so that the user is unable to type in textfields (such as game chat) with smart keymapping enabled. Also fixes an issue where elements on screen are unable to be clicked. Fixes https://github.com/PlayCover/PlayCover/issues/1086.