### PR TITLE
fix: rref dictionary crash (da heck apple)

### DIFF
--- a/PlayTools/MysticRunes/PlayedApple.swift
+++ b/PlayTools/MysticRunes/PlayedApple.swift
@@ -37,9 +37,10 @@ public class PlayKeychain: NSObject {
 
     private static func getKeychainPath(_ attributes: NSDictionary) -> URL {
         let keychainFolder = getKeychainDirectory()
-        if attributes["r_Ref"] as? Int == 1 {
-            attributes.setValue("keys", forKey: "class")
-        }
+        // if attributes["r_Ref"] as? Int == 1 {
+            // attributes.setValue("keys", forKey: "class")
+            // What the hell Apple
+        // }
         // Generate a key path based on the key attributes
         let accountName = attributes[kSecAttrAccount as String] as? String ?? ""
         let serviceName = attributes[kSecAttrService as String] as? String ?? ""


### PR DESCRIPTION
(This is my guess) Maybe Apple has made the keychain dictionary immutable, so this would blow up

Should fix https://github.com/PlayCover/PlayCover/issues/1240