### PR TITLE
Fix app crash or freeze on quit

### DIFF
--- a/PlayTools/PlayCover.swift
+++ b/PlayTools/PlayCover.swift
@@ -35,7 +35,39 @@ public class PlayCover: NSObject {
             queue: OperationQueue.main
         ) { notif in
             if PlayScreen.shared.nsWindow?.isEqual(notif.object) ?? false {
-                AKInterface.shared!.terminateApplication()
+                // Step 1: Resign active
+                for scene in UIApplication.shared.connectedScenes {
+                    scene.delegate?.sceneWillResignActive?(scene)
+                    NotificationCenter.default.post(name: UIScene.willDeactivateNotification,
+                                                    object: scene)
+                }
+                UIApplication.shared.delegate?.applicationWillResignActive?(UIApplication.shared)
+                NotificationCenter.default.post(name: UIApplication.willResignActiveNotification,
+                                                object: UIApplication.shared)
+
+                // Step 2: Enter background
+                for scene in UIApplication.shared.connectedScenes {
+                    scene.delegate?.sceneDidEnterBackground?(scene)
+                    NotificationCenter.default.post(name: UIScene.didEnterBackgroundNotification,
+                                                    object: scene)
+                }
+                UIApplication.shared.delegate?.applicationDidEnterBackground?(UIApplication.shared)
+                NotificationCenter.default.post(name: UIApplication.didEnterBackgroundNotification,
+                                                object: UIApplication.shared)
+
+                // Step 2.5: End UIBackgroundTask
+                // There is an expiration handler, but idk how to invoke it. Skip for now.
+
+                // Step 3: Terminate
+                UIApplication.shared.delegate?.applicationWillTerminate?(UIApplication.shared)
+                NotificationCenter.default.post(name: UIApplication.willTerminateNotification,
+                                                object: UIApplication.shared)
+                DispatchQueue.main.async(execute: AKInterface.shared!.terminateApplication)
+
+                // Step 3.5: End BGTask
+                // BGTask typically runs in another process and is tricky to terminate.
+                // It may run into infinite loops, end up silently heating the device up.
+                // This actually happens for ToF. Hope future developers can solve this.
             }
         }
     }


### PR DESCRIPTION
Fixes PlayCover/PlayCover/issues/689 and PlayCover/PlayCover/issues/1165

This issue occasionally occurs to Genshin Impact, but always happens for most other games. For example Ni No Kuni and ToF, which have 100% probability of encountering this. With this PR, neither of them crash or freeze anymore.

The root cause of this issue lies in the fact that the app is being forcefully terminated without completing its termination procedures. These procedures may involve ending metal commands and synchronizing data to disk, among other things. In the worst-case scenario, if these termination tasks are not completed successfully, it can result in data corruption and lead to the game crashing upon subsequent launches.

This PR follows the termination procedures [here](https://developer.apple.com/documentation/uikit/app_and_environment/scenes/preparing_your_ui_to_run_in_the_background/about_the_background_execution_sequence#2928661), blocking main thread before all these callbacks end.

This may delay app termination for up to 5 seconds, which is comparable to normal termination time of other macOS apps.

Update: Tested more on Genshin and Honkai Star Rail and works perfectly.
