### PR TITLE
Limit max polling rate

### DIFF
--- a/PlayTools/Controls/Backend/Action/PlayAction.swift
+++ b/PlayTools/Controls/Backend/Action/PlayAction.swift
@@ -313,11 +313,6 @@ class SwipeAction: Action {
     var location: CGPoint = CGPoint.zero
     private var id: Int?
     let timer = DispatchSource.makeTimerSource(flags: [], queue: PlayInput.touchQueue)
-    // Mouse polling rate as high as 3000 causes issue to some games
-    static private let maxPollingRate = 125
-    static private let minMoveInterval =
-        DispatchTimeInterval.milliseconds(1000/maxPollingRate)
-    private var lastMoveWhen = DispatchTime.now()
     init() {
         timer.schedule(deadline: DispatchTime.now() + 1, repeating: 0.1, leeway: DispatchTimeInterval.milliseconds(50))
         timer.setEventHandler(qos: .userInteractive, handler: self.checkEnded)
@@ -361,19 +356,11 @@ class SwipeAction: Action {
             Toucher.touchcam(point: location, phase: UITouch.Phase.began, tid: &id)
             timer.resume()
         }
+        // count touch duration
+        counter += 1
         self.location.x += deltaX
         self.location.y -= deltaY
 
-        // limit move frequency
-        let now = DispatchTime.now()
-        if now < lastMoveWhen.advanced(by: SwipeAction.minMoveInterval) {
-//            Toast.showHint(title: String(now.rawValue - lastMoveWhen.rawValue))
-            return
-        }
-        lastMoveWhen = now
-
-        // count touch duration
-        counter += 1
         Toucher.touchcam(point: self.location, phase: UITouch.Phase.moved, tid: &id)
     }
 

--- a/PlayTools/Controls/Frontend/ControlMode.swift
+++ b/PlayTools/Controls/Frontend/ControlMode.swift
@@ -71,9 +71,8 @@ public class ControlMode: Equatable {
             })
         }
 
-        AKInterface.shared!.setupMouseMoved({deltaX, deltaY in
-            self.mouseAdapter.handleMove(deltaX: deltaX, deltaY: deltaY)
-        })
+        // Mouse polling rate as high as 1000 causes issue to some games
+        setupMouseMoved(maxPollingRate: 125)
 
         AKInterface.shared!.setupMouseButton(left: true, right: false, {_, pressed in
             self.mouseAdapter.handleLeftButton(pressed: pressed)
@@ -88,6 +87,31 @@ public class ControlMode: Equatable {
         })
 
         ActionDispatcher.build()
+    }
+
+    private func setupMouseMoved(maxPollingRate: Int) {
+        let minMoveInterval =
+            DispatchTimeInterval.milliseconds(1000/maxPollingRate)
+        var lastMoveWhen = DispatchTime.now()
+        // Repeat the return value of last processed event
+        var consumed = true
+        var movement: CGVector = CGVector()
+
+        AKInterface.shared!.setupMouseMoved({deltaX, deltaY in
+            // limit move frequency
+            let now = DispatchTime.now()
+            movement.dy += deltaY
+            movement.dx += deltaX
+            if now < lastMoveWhen.advanced(by: minMoveInterval) {
+                return consumed
+            }
+
+            lastMoveWhen = now
+            consumed = self.mouseAdapter.handleMove(deltaX: movement.dx, deltaY: movement.dy)
+            movement.dy = 0
+            movement.dx = 0
+            return consumed
+        })
     }
 
     public func set(_ mode: ControlModeLiteral) {


### PR DESCRIPTION
Fixes some Wuthering Waves pointer issue

Previously, playcover would deliver a touch event to the game whenever a mouse event arrives. However, some mouses have poll rate over 1000 which is far beyond the designed processing ability of a touchscreen game.

In this PR, a swipe action's polling rate is limited to no more than 125, so as to fix some issues caused by high polling rate.

This might also fix PlayCover/PlayCover/issues/1483, in such a case: that the touching system is overwhelmed by too many move events, and the system decides to randomly drop some events, and eventually drops a touch_end event. If people are reporting it only on mouse but not touchpad, that could be this case.  

Personally I'm playing with a touchpad and everything works perfectly. I don't have a working mouse so I can't say for sure if it's actually fixed. Someone if you have that issue please help me test thx.