### PR TITLE
Fix random zoom in zoom out

### DIFF
--- a/PlayTools/Controls/ActionDispatcher.swift
+++ b/PlayTools/Controls/ActionDispatcher.swift
@@ -149,6 +149,13 @@ public class ActionDispatcher {
         }
     }
 
+    static public func invalidateNonButtonActions() {
+        for action in actions 
+        where !(action as? ButtonAction != nil || action is JoystickAction){
+            action.invalidate()
+        }
+    }
+
     static public func getDispatchPriority(key: String) -> ActionDispatchPriority? {
         if let priority = directionPadHandlers.firstIndex(where: { handlers in
             handlers.contains(where: { handler in

--- a/PlayTools/Controls/ActionDispatcher.swift
+++ b/PlayTools/Controls/ActionDispatcher.swift
@@ -141,6 +141,10 @@ public class ActionDispatcher {
 
     static public var cursorHideNecessary = true
 
+    /**
+        Lift off (release) all actions' touch points.
+        Would be called during mode switching where target mode shouldn't have any touch remain.
+    */
     static public func invalidateActions() {
         for action in actions {
             // This is just a rescue feature, in case any key stuck pressed for any reason
@@ -149,6 +153,15 @@ public class ActionDispatcher {
         }
     }
 
+    /**
+        Lift off (release) touch points of actions that moves freely under control of the user. (e.g. camera control action)
+        Would be called during every mode switching where `invalidateActions` is not called.
+        In such scenario button-type actions are not released, because users may continue using them across different modes.
+        (e.g. holding W while unhiding cursor to click something)
+
+        But non-button-type actions (e.g. camera control action, fake mouse action) are unlikely used across modes.
+        If they're not released, they would interfere with and ruin the game's camera control (becomes random zoom in zoom out)
+    */
     static public func invalidateNonButtonActions() {
         for action in actions 
         where !(action as? ButtonAction != nil || action is JoystickAction){

--- a/PlayTools/Controls/Backend/Action/PlayAction.swift
+++ b/PlayTools/Controls/Backend/Action/PlayAction.swift
@@ -68,10 +68,12 @@ class DraggableButtonAction: ButtonAction {
                 AKInterface.shared!.hideCursor()
             }
         } else {
-            ActionDispatcher.unregister(key: KeyCodeNames.mouseMove)
             Toucher.touchcam(point: releasePoint, phase: UITouch.Phase.ended, tid: &id)
-            if !mode.cursorHidden() {
-                AKInterface.shared!.unhideCursor()
+            if id == nil {
+                ActionDispatcher.unregister(key: KeyCodeNames.mouseMove)
+                if !mode.cursorHidden() {
+                    AKInterface.shared!.unhideCursor()
+                }
             }
         }
     }
@@ -397,11 +399,14 @@ class SwipeAction: Action {
             return
         }
         Toucher.touchcam(point: self.location, phase: UITouch.Phase.ended, tid: &id)
-        timer.suspend()
-        delay(0.02) {
-            self.cooldown = false
+        // Touch might somehow fail to end
+        if id == nil {
+            timer.suspend()
+            delay(0.02) {
+                self.cooldown = false
+            }
+            cooldown = true
         }
-        cooldown = true
     }
 
     func invalidate() {
@@ -436,8 +441,10 @@ class FakeMouseAction: Action {
 //        DispatchQueue.main.async {
 //            Toast.showHint(title: " lift Fake mouse", text: ["\(self.pos)"])
 //        }
-        ActionDispatcher.unregister(key: KeyCodeNames.fakeMouse)
         Toucher.touchcam(point: pos, phase: UITouch.Phase.ended, tid: &id)
+        if id == nil {
+            ActionDispatcher.unregister(key: KeyCodeNames.fakeMouse)
+        }
     }
 
     func movementHandler(xValue: CGFloat, yValue: CGFloat) {

--- a/PlayTools/Controls/Backend/Action/PlayAction.swift
+++ b/PlayTools/Controls/Backend/Action/PlayAction.swift
@@ -364,34 +364,8 @@ class SwipeAction: Action {
         }
         // count touch duration
         counter += 1
-        let newX = self.location.x + deltaX 
-        let newY = self.location.y - deltaY
-        // Check if new location is out of window (position overflows)
-        // May cause resource leak in some games if point moves out of window
-        // If this is out of window then lift off instead
-        if newX < 0 || newY < 0 || newX > screen.width || newY > screen.height {
-//            Toast.showHint(title: newX.description + newY.description)
-            // Move the point as far as possible, in case it always overflows and gets stuck
-            if newX < 0 {
-                self.location.x = 0
-            } else if newX > screen.width {
-                self.location.x = screen.width
-            } else {
-                self.location.x = newX
-            }
-
-            if newY < 0 {
-                self.location.y = 0
-            } else if newY > screen.height {
-                self.location.y = screen.height
-            } else {
-                self.location.y = newY
-            }
-            doLiftOff()
-            return
-        }
-        self.location.x = newX
-        self.location.y = newY
+        self.location.x += deltaX
+        self.location.y -= deltaY
     }
 
     public func doLiftOff() {

--- a/PlayTools/Controls/Backend/Action/PlayAction.swift
+++ b/PlayTools/Controls/Backend/Action/PlayAction.swift
@@ -335,6 +335,7 @@ class SwipeAction: Action {
     // if should wait before beginning next touch
     var cooldown = false
     var lastCounter = 0
+    var shouldEdgeReset = false
 
     func checkEnded() {
         if self.counter == self.lastCounter {
@@ -347,6 +348,34 @@ class SwipeAction: Action {
         self.lastCounter = self.counter
      }
 
+    private func checkXYOutOfWindow(coordX: CGFloat, coordY: CGFloat) -> Bool {
+        return coordX < 0 || coordY < 0 || coordX > screen.width || coordY > screen.height
+    }
+
+    /**
+     get a multiplier to current velocity, so as to make the predicted coordinate inside window
+     */
+    private func getVelocityScaler(predictX: CGFloat, predictY: CGFloat,
+                                   nowX: CGFloat, nowY: CGFloat) -> CGFloat {
+        var scaler = 1.0
+        if predictX < 0 {
+            let scale =  (0 - nowX) / (predictX - nowX)
+            scaler = min(scaler, scale)
+        } else if predictX > screen.width {
+            let scale =  (screen.width - nowX) / (predictX - nowX)
+            scaler = min(scaler, scale)
+        }
+
+        if predictY < 0 {
+            let scale =  (0 - nowY) / (predictY - nowY)
+            scaler = min(scaler, scale)
+        } else if predictY > screen.height {
+            let scale =  (screen.height - nowY) / (predictY - nowY)
+            scaler = min(scaler, scale)
+        }
+        return scaler
+    }
+
     public func move(from: () -> CGPoint?, deltaX: CGFloat, deltaY: CGFloat) {
         if id == nil {
             if cooldown {
@@ -358,14 +387,43 @@ class SwipeAction: Action {
             Toucher.touchcam(point: location, phase: UITouch.Phase.began, tid: &id)
             timer.resume()
         } else {
+            if shouldEdgeReset {
+                doLiftOff()
+                return
+            }
             // 1. Put location update after touch action, so that final `end` touch has different location
             // 2. If `began` touched, do not `move` touch at the same time, otherwise the two may conflict
             Toucher.touchcam(point: self.location, phase: UITouch.Phase.moved, tid: &id)
         }
+        // Scale movement down, so that an edge reset won't cause a too short touch sequence
+        var scaledDeltaX = deltaX
+        var scaledDeltaY = deltaY
+        // A scroll must have this number of touch events to get inertia
+        let minTotalCounter = 16
+        if counter < minTotalCounter {
+            // Suppose the touch velocity doesn't change
+            let predictX = self.location.x + CGFloat((minTotalCounter - counter)) * deltaX
+            let predictY = self.location.y - CGFloat((minTotalCounter - counter)) * deltaY
+            if checkXYOutOfWindow(coordX: predictX, coordY: predictY) {
+                // Velocity needs scale down
+                let scaler = getVelocityScaler(predictX: predictX, predictY: predictY,
+                                               nowX: self.location.x, nowY: self.location.y)
+                scaledDeltaX *= scaler
+                scaledDeltaY *= scaler
+            }
+        }
         // count touch duration
         counter += 1
-        self.location.x += deltaX
-        self.location.y -= deltaY
+        self.location.x += scaledDeltaX
+        self.location.y -= scaledDeltaY
+        // Check if new location is out of window (position overflows)
+        // May fail in some games if point moves out of window
+        // If next touch is predicted out of window then this lift off instead
+        if checkXYOutOfWindow(coordX: self.location.x + scaledDeltaX,
+                              coordY: self.location.y - scaledDeltaY) {
+            // Wait until next event to lift off, so as to maintain smooth scrolling speed
+            shouldEdgeReset = true
+        }
     }
 
     public func doLiftOff() {
@@ -380,6 +438,7 @@ class SwipeAction: Action {
                 self.cooldown = false
             }
             cooldown = true
+            shouldEdgeReset = false
         }
     }
 

--- a/PlayTools/Controls/Backend/Action/PlayAction.swift
+++ b/PlayTools/Controls/Backend/Action/PlayAction.swift
@@ -418,6 +418,7 @@ class FakeMouseAction: Action {
     }
 
     func invalidate() {
+        ActionDispatcher.unregister(key: KeyCodeNames.fakeMouse)
         Toucher.touchcam(point: pos ?? CGPoint(x: 10, y: 10),
                          phase: UITouch.Phase.ended, tid: &self.id)
     }

--- a/PlayTools/Controls/Frontend/ControlMode.swift
+++ b/PlayTools/Controls/Frontend/ControlMode.swift
@@ -111,6 +111,11 @@ public class ControlMode: Equatable {
 
                 if mode == .OFF || mode == .EDITOR {
                     ActionDispatcher.invalidateActions()
+                } else {
+                    // In case any touch point failed to release
+                    // (might because of system glitch)
+                    // Work around random zoom in zoom out
+                    ActionDispatcher.invalidateNonButtonActions()
                 }
 
                 AKInterface.shared!.unhideCursor()
@@ -118,6 +123,11 @@ public class ControlMode: Equatable {
                 NotificationCenter.default.post(name: NSNotification.Name.playtoolsCursorWillHide,
                                                 object: nil, userInfo: [:])
                 AKInterface.shared!.hideCursor()
+
+                // Fix when people hold fake mouse while pressing option
+                // and it becomes random zoom in zoom out
+                ActionDispatcher.invalidateNonButtonActions()
+
                 if screen.fullscreen {
                     screen.switchDock(false)
                 }

--- a/PlayTools/Controls/PTFakeTouch/PTFakeMetaTouch.m
+++ b/PlayTools/Controls/PTFakeTouch/PTFakeMetaTouch.m
@@ -11,29 +11,31 @@
 #import "UIApplication+Private.h"
 #import "UIEvent+Private.h"
 #import "CoreFoundation/CFRunLoop.h"
+#import <stdatomic.h>
 #include <dlfcn.h>
 #include <string.h>
 
 static NSMutableArray *livingTouchAry;
-uint64_t reusageMask = 0;
+atomic_ullong reusageMask = ATOMIC_VAR_INIT(0);
 static CFRunLoopSourceRef source;
 
-static UITouch *toStationarify = NULL;
 NSLock *lock;
 
 void eventSendCallback(void* info) {
     UIEvent *event = [[UIApplication sharedApplication] _touchesEvent];
     [event _clearTouches];
+    // Step1: copy touches and record began touches and mark recyclable touches
+    NSMutableArray *begunTouchAry = [[NSMutableArray alloc] init];
     [lock lock];
     [livingTouchAry enumerateObjectsUsingBlock:^(UITouch *aTouch, NSUInteger idx, BOOL *stop) {
         switch (aTouch.phase) {
             case UITouchPhaseEnded:
             case UITouchPhaseCancelled:
-                // set this bit to 0
-                reusageMask |= 1ull<<idx;
+                // set this bit to 1
+                atomic_fetch_or(&reusageMask, 1ull<<idx);
                 break;
             case UITouchPhaseBegan:
-                toStationarify = aTouch;
+                [begunTouchAry addObject:aTouch];
                 break;
             default:
                 break;
@@ -41,7 +43,20 @@ void eventSendCallback(void* info) {
         [event _addTouch:aTouch forDelayedDelivery:NO];
     }];
     [lock unlock];
+
+    // Step2: send event
     [[UIApplication sharedApplication] sendEvent:event];
+
+    // Step 3: change "began" touches to "moved"
+    // Do not let a "began" appear twice on a point
+    for (UITouch *touch in begunTouchAry) {
+        // Double check "began", because phase may have changed
+        if ([touch phase] == UITouchPhaseBegan) {
+            @synchronized (touch) {
+                [touch setPhaseAndUpdateTimestamp:UITouchPhaseMoved];
+            }
+        }
+    }
 }
 
 @implementation PTFakeMetaTouch
@@ -60,26 +75,26 @@ void eventSendCallback(void* info) {
 
 + (NSInteger)fakeTouchId: (NSInteger)pointId AtPoint: (CGPoint)point withTouchPhase: (UITouchPhase)phase inWindow: (UIWindow*)window onView:(UIView*)view {
     UITouch* touch = NULL;
-    if(toStationarify != NULL) {
-        // in case this is changed during the operations
-        touch = toStationarify;
-        toStationarify = NULL;
-        if(touch.phase == UITouchPhaseBegan) {
-            [touch setPhaseAndUpdateTimestamp:UITouchPhaseMoved];
-        }
-    }
     // respect the semantics of touch phase, allocate new touch on touch began.
     if(phase == UITouchPhaseBegan) {
         touch = [[UITouch alloc] initAtPoint:point inWindow:window onView:view];
-        if(reusageMask == 0){
+        // Find and clear any 1 bit if possible
+        if(atomic_load(&reusageMask) == 0){
             pointId = [livingTouchAry count];
         }else{
             // reuse previous ID
             pointId = 0;
-            while( !(reusageMask & (1ull<<pointId)) ){
+            // It is guanranteed other thread only "set" but not "clear" bit
+            // So this is safe even if mask changes around here
+            while( !(atomic_load(&reusageMask) & (1ull<<pointId)) ){
                 pointId++;
             }
-            reusageMask &= ~(1ull<<pointId);
+            // issue: this could fail if not atomic
+            // How:
+            // 1. Other thread read
+            // 2. This thread read and write
+            // 3. Other thread write
+            atomic_fetch_and(&reusageMask, ~(1ull<<pointId));
         }
         [lock lock];
         [livingTouchAry setObject:touch atIndexedSubscript:pointId];
@@ -90,11 +105,13 @@ void eventSendCallback(void* info) {
             // previous touch began event not yet captured by runloop. Ignore this move
             return pointId;
         }
-        [touch setLocationInWindow:point];
-        [touch setPhaseAndUpdateTimestamp:phase];
+        @synchronized (touch) {
+            [touch setLocationInWindow:point];
+            [touch setPhaseAndUpdateTimestamp:phase];
+        }
     }
     CFRunLoopSourceSignal(source);
-    // Set phase might somehow fail
+    // Check on actual phase of touch
     if([touch phase] == UITouchPhaseEnded || [touch phase] == UITouchPhaseCancelled) {
         pointId = -1;
     }

--- a/PlayTools/Controls/PTFakeTouch/PTFakeMetaTouch.m
+++ b/PlayTools/Controls/PTFakeTouch/PTFakeMetaTouch.m
@@ -83,6 +83,7 @@ void eventSendCallback(void* info) {
         // Find and clear any 1 bit if possible
         if(atomic_load(&reusageMask) == 0){
             pointId = [livingTouchAry count];
+            [lock lock];
         }else{
             // reuse previous ID
             pointId = 0;
@@ -96,9 +97,12 @@ void eventSendCallback(void* info) {
             // 1. Other thread read
             // 2. This thread read and write
             // 3. Other thread write
+            [lock lock];
             atomic_fetch_and(&reusageMask, ~(1ull<<pointId));
+            // These must be locked together, because otherwise
+            // After we occupy this id, other thread may release it again,
+            // before we actually replace the UITouch
         }
-        [lock lock];
         [livingTouchAry setObject:touch atIndexedSubscript:pointId];
         [lock unlock];
     } else {

--- a/PlayTools/Controls/PTFakeTouch/PTFakeMetaTouch.m
+++ b/PlayTools/Controls/PTFakeTouch/PTFakeMetaTouch.m
@@ -94,7 +94,8 @@ void eventSendCallback(void* info) {
         [touch setPhaseAndUpdateTimestamp:phase];
     }
     CFRunLoopSourceSignal(source);
-    if(phase == UITouchPhaseEnded || phase == UITouchPhaseCancelled) {
+    // Set phase might somehow fail
+    if([touch phase] == UITouchPhaseEnded || [touch phase] == UITouchPhaseCancelled) {
         pointId = -1;
     }
     return pointId;

--- a/PlayTools/Controls/PTFakeTouch/PTFakeMetaTouch.m
+++ b/PlayTools/Controls/PTFakeTouch/PTFakeMetaTouch.m
@@ -51,8 +51,10 @@ void eventSendCallback(void* info) {
     // Do not let a "began" appear twice on a point
     for (UITouch *touch in begunTouchAry) {
         // Double check "began", because phase may have changed
-        if ([touch phase] == UITouchPhaseBegan) {
-            @synchronized (touch) {
+        @synchronized (touch) {
+            // Check condition needs to be synchronized too,
+            // otherwise phase might also change after condition met
+            if ([touch phase] == UITouchPhaseBegan) {
                 [touch setPhaseAndUpdateTimestamp:UITouchPhaseMoved];
             }
         }


### PR DESCRIPTION
Fixes PlayCover/PlayCover/issues/1483 and PlayCover/PlayCover/issues/767 and PlayCover/PlayCover/issues/1492

## Update 0530

I think I finally found the real cause (many thanks to testing help of discord user @Tyler): The data race in `PTFakeMetaTouch`

Basically a `reusageMask` is used to record allocation of `UITouch` objects to touch points. The fake touch process has two procedures, `sendEventCallback` runs in main thread, and `touchcam` runs in `touchqueue` which is a separate thread. For `reusageMask`, there is a `&=` operation in `touchqueue` and a `|=` operation in main thread. 

Theoretically, there should be some protection method on this cross-thread data manipulation, but for some reason there are not. How could this cause the random zoom-in zoom-out issue?

So the `&=` operation in `touchcam` is used to allocate an object for the touch point, and the `|=` operation in `sendEventCallback` for releasing an object for subsequent use. These two contains firstly reading the value, then doing the calculation, then writing it back. The operation sequence could be like this:

1. Thread A read data
2. Thread B read data
3. Thread A write back data
4. Thread B write back data

So clearly in this situation, the write operation of thread A doesn't take effect. It was overriden by thread B. That is, the `&=` operation and `|=` operation could fail. Let thread A be the `touchqueue` thread, and the object allocation operation fails. In this case, this point may continue its lifecycle, but as long as another point needs an allocation too, the former object may be released immediately. This would cause its lifecycle ends without an `ended` event, and the game would always think this touch point is on screen, while we completely lost control of it. That would cause a ghost touch point always on the screen. And at this point if you try to pan or rotate, there are two touch points on the screen and it would be recognized as a pinch gesture. 

What if the `|=` operation fails? In this case, we failed to release an object. That object would always exist in the touch array in an `ended` phase, which interestingly wouldn't cause any issue, except maybe several bytes of memory leak. In summary, the only issue that data race would cause is the ghost touch issue, thus a random zoom-in zoom-out.

Solution is simply making `reusageMask` atomic and all operations regarding it atomic.

## Update 0531

Thanks to extensive testing of @RyufM, I found another concurency issue.

When the `&=` operation is executed in `touchqueue` thread, it occupies an ID for use, then replaces that object with a new object. At the same time, in the main thread, the code checks if the touch object at every ID is in an ended state and if so, mark that ID as free. The execution sequence could be like this:

1. `touchqueue` marks an ID as occupied
2. main thread checks the object at the same ID
3. main thread found it's in ended state and marks this ID as free
4. `touchqueue` replaces the touch object with a new one

In this case, even when that ID has a new object, it is still marked as free. Subsequent ID allocation requests would occupy that same ID and replace that new object, making its lifecycle end without and "ended" event, thus becoming a ghost touch point.

Solution is to use a mutex lock to lock the ID occupation operation and the object replacement operation together.

Below are the original description which may help but doesn't really matter:

--------
This PR tries to fix things in three aspects:

1. Pressed keys may not release when people press option to hide/unhide cursor. (as described by @kang49)

For that, I have added release of all touch points related to mouse whenever option is pressed.

6. The game developer might assume every touch point is inside window. If a touch point ends up out of window, the game may somehow fail to end it properly and cause resources to leak over time. So I limited every `swipeAction` point inside the window.

The `moved` touch action inside `swipeAction` is moved before position update, so as to fix some glitch, where the initial touch position becomes the first `moved` touch (which is a little shifted from the `began` touch), and the terminal velocity becomes 0 because the `end` touch has the same position as the last `moved` touch.

7. When touch point phase is set to ended, it might fail. Previous implementation assumes that this alwasys succeed, so as to create an inconsistency between the actual phase of the touch point and the recorded point phase. When we think it's ended, it might still be moved and we lost control of it. By checking on the actual phase of a point, this is mitigated.

Let me know if your issue behaves differently or this PR doesn't fix your issue. (and most importantly, describe your issue, what triggers it, what can be done to temporarily fix it. It's better to provide screen recording of your issue.)