### PR TITLE
Fix scroll wheel zoom glitch

### DIFF
--- a/PlayTools/Controls/Backend/Action/PlayAction.swift
+++ b/PlayTools/Controls/Backend/Action/PlayAction.swift
@@ -263,7 +263,7 @@ class CameraAction: Action {
     static var swipeDrag = SwipeAction()
     var key: String!
     var center: CGPoint
-    var distance1: CGFloat = 100, distance2: CGFloat = 100
+
     init(data: MouseArea) {
         self.key = data.keyName
         let centerX = data.transform.xCoord.absoluteX
@@ -284,20 +284,21 @@ class CameraAction: Action {
     }
 
     func scaleUpdated(_ deltaX: CGFloat, _ deltaY: CGFloat) {
-        let distance = distance1 + distance2
-        let moveY = deltaY * (distance / 100.0)
-        distance1 += moveY
-        distance2 += moveY
-
+        let centerY = screen.height/2
+        let centerX = screen.width/2
         swipeScale1.move(from: {
-            self.distance1 = 100
-            return CGPoint(x: center.x, y: center.y - 100)
-        }, deltaX: 0, deltaY: moveY)
+            CGPoint(x: centerX, y: centerY/2)
+        }, deltaX: 0, deltaY: deltaY)
 
         swipeScale2.move(from: {
-            self.distance2 = 100
-            return CGPoint(x: center.x, y: center.y + 100)
-        }, deltaX: 0, deltaY: -moveY)
+            CGPoint(x: centerX, y: centerY + (centerY/2))
+        }, deltaX: 0, deltaY: -deltaY)
+        // a move can't be longer than `centerY/16` due to the velocity limiter of `CameraAction`
+        // so lifting off before two touches meet
+        if swipeScale2.location.y - centerY < centerY/16 {
+            swipeScale1.doLiftOff()
+            swipeScale2.doLiftOff()
+        }
     }
 
     static func dragUpdated(_ deltaX: CGFloat, _ deltaY: CGFloat) {


### PR DESCRIPTION
Fixes PlayCover/PlayCover/issues/1022

## Previous Implementation

Two touch points starting from the center of camera action plus/minus 100 in y axis and not changing the x axis, moving towards each other with velocity exponentially decrease and apart from each other exponentially increase.

## New Implementation

Two touch points starting from upper/lower 1/4 equally divider point of the screen, with x axis in the center and y axis having equal distance to up/bottom edge and center. The moving speed is as the scroll wheel's is, but touches would lift off when they're to touch each other or to touch edge.

Actually #144 already limited touch points inside window, so that the exact glitch of PlayCover/PlayCover/issues/1022 no longer happens. But that also breaks how original scroll wheel zooming function works and makes it randomly move camera view-angle up and down. This PR fixes this.

The choice of moving direction of vertically up and down is because that, this line has the least possible buttons, as it's the farthest to a human's finger on a mobile device.