### PR TITLE
Fix fake mouse occasionally crash

### DIFF
--- a/PlayTools/Controls/Backend/Action/PlayAction.swift
+++ b/PlayTools/Controls/Backend/Action/PlayAction.swift
@@ -449,7 +449,7 @@ class SwipeAction: Action {
 
 class FakeMouseAction: Action {
     var id: Int?
-    var pos: CGPoint!
+    var pos: CGPoint = CGPoint()
     public init() {
         ActionDispatcher.register(key: KeyCodeNames.fakeMouse, handler: buttonPressHandler)
         ActionDispatcher.register(key: KeyCodeNames.fakeMouse, handler: buttonLiftHandler)
@@ -488,7 +488,7 @@ class FakeMouseAction: Action {
 
     func invalidate() {
         ActionDispatcher.unregister(key: KeyCodeNames.fakeMouse)
-        Toucher.touchcam(point: pos ?? CGPoint(x: 10, y: 10),
+        Toucher.touchcam(point: pos,
                          phase: UITouch.Phase.ended, tid: &self.id)
     }
 


### PR DESCRIPTION
## The issue

After the keymap loads, if the first fake mouse event is a key release event (instead of a key pressed event), the game would crash.

## How to reproduce

Open any game. Switch to another window. Press left mouse button and while holding it, switch to the game window with cmd+tab. Release left mouse button inside game window, the game will crash.

To trigger the issue, mouse can't have any clicks in the game window before that release action. Or you can open keymap editor then close it, that would re-load the keymap and "clear" previous clicks.

## Cause

The mouse position is obtained in mouse pressed event and mouse moved event. And the position variable was force unwrapped. So if a released event comes before any pressed event or moved event (actually no moved event would reach there if there were no pressed event, as the event handler for the moved event is only registered during handling of the pressed event), handler of released event would be force unwrapping a `nil` value.

## Fix

Don't make it an optional, and give it an initial pos during class initialization. That would lead to an extra touch ended event be sent, but that event would eventually be ignored for it has empty point ID.