### PR TITLE
Support mapping Control key modifier combination

### DIFF
--- a/AKPlugin.swift
+++ b/AKPlugin.swift
@@ -66,7 +66,7 @@ class AKPlugin: NSObject, Plugin {
     }
 
     private var modifierFlag: UInt = 0
-    func setupKeyboard(keyboard: @escaping(UInt16, Bool, Bool) -> Bool,
+    func setupKeyboard(keyboard: @escaping(UInt16, Bool, Bool, Bool) -> Bool,
                        swapMode: @escaping() -> Bool) {
         func checkCmd(modifier: NSEvent.ModifierFlags) -> Bool {
             if modifier.contains(.command) {
@@ -81,7 +81,8 @@ class AKPlugin: NSObject, Plugin {
             if checkCmd(modifier: event.modifierFlags) {
                 return event
             }
-            let consumed = keyboard(event.keyCode, true, event.isARepeat)
+            let consumed = keyboard(event.keyCode, true, event.isARepeat,
+                                    event.modifierFlags.contains(.control))
             if consumed {
                 return nil
             }
@@ -91,7 +92,8 @@ class AKPlugin: NSObject, Plugin {
             if checkCmd(modifier: event.modifierFlags) {
                 return event
             }
-            let consumed = keyboard(event.keyCode, false, false)
+            let consumed = keyboard(event.keyCode, false, false,
+                                    event.modifierFlags.contains(.control))
             if consumed {
                 return nil
             }
@@ -104,13 +106,15 @@ class AKPlugin: NSObject, Plugin {
             let pressed = self.modifierFlag < event.modifierFlags.rawValue
             let changed = self.modifierFlag ^ event.modifierFlags.rawValue
             self.modifierFlag = event.modifierFlags.rawValue
-            if pressed && NSEvent.ModifierFlags(rawValue: changed).contains(.option) {
+            let changedFlags = NSEvent.ModifierFlags(rawValue: changed)
+            if pressed && changedFlags.contains(.option) {
                 if swapMode() {
                     return nil
                 }
                 return event
             }
-            let consumed = keyboard(event.keyCode, pressed, false)
+            let consumed = keyboard(event.keyCode, pressed, false,
+                                    event.modifierFlags.contains(.control))
             if consumed {
                 return nil
             }

--- a/PlayTools/Controls/Frontend/ControlMode.swift
+++ b/PlayTools/Controls/Frontend/ControlMode.swift
@@ -61,8 +61,9 @@ public class ControlMode: Equatable {
             }
         }
 
-        AKInterface.shared!.setupKeyboard(keyboard: { keycode, pressed, isRepeat in
-            self.keyboardAdapter.handleKey(keycode: keycode, pressed: pressed, isRepeat: isRepeat)},
+        AKInterface.shared!.setupKeyboard(keyboard: { keycode, pressed, isRepeat, ctrlModified in
+            self.keyboardAdapter.handleKey(keycode: keycode, pressed: pressed,
+                                           isRepeat: isRepeat, ctrlModified: ctrlModified)},
           swapMode: ModeAutomaton.onOption)
 
         if PlaySettings.shared.enableScrollWheel {

--- a/PlayTools/Controls/Frontend/EventAdapter/Keyboard/Instances/EditorKeyboardEventAdapter.swift
+++ b/PlayTools/Controls/Frontend/EventAdapter/Keyboard/Instances/EditorKeyboardEventAdapter.swift
@@ -16,10 +16,12 @@ public class EditorKeyboardEventAdapter: KeyboardEventAdapter {
         .rightGUI,
         .leftAlt,
         .rightAlt,
+        .leftControl,
+        .rightControl,
         .printScreen
     ]
 
-    public func handleKey(keycode: UInt16, pressed: Bool, isRepeat: Bool) -> Bool {
+    public func handleKey(keycode: UInt16, pressed: Bool, isRepeat: Bool, ctrlModified: Bool) -> Bool {
         if AKInterface.shared!.cmdPressed || !pressed || isRepeat {
             return false
         }
@@ -31,7 +33,16 @@ public class EditorKeyboardEventAdapter: KeyboardEventAdapter {
 //                Toast.showHint(title: "Invalid Key", text: ["This key is intentionally forbidden. Keyname: \(name)"])
             return false
         }
-        EditorController.shared.setKey(rawValue)
+
+        if ctrlModified {
+            if let name = KeyCodeNames.virtualCodes[keycode] {
+                // Setkey by name does not work with all kinds of mapping
+                EditorController.shared.setKey("⌃" + name)
+            }
+        } else {
+            EditorController.shared.setKey(rawValue)
+        }
+
         return true
     }
 

--- a/PlayTools/Controls/Frontend/EventAdapter/Keyboard/Instances/TouchscreenKeyboardEventAdapter.swift
+++ b/PlayTools/Controls/Frontend/EventAdapter/Keyboard/Instances/TouchscreenKeyboardEventAdapter.swift
@@ -10,14 +10,41 @@ import Foundation
 // Keyboard events handler when keyboard mapping is on
 
 public class TouchscreenKeyboardEventAdapter: KeyboardEventAdapter {
-    public func handleKey(keycode: UInt16, pressed: Bool, isRepeat: Bool) -> Bool {
+    private var modifiedKeys: [UInt16] = []
+    public func handleKey(keycode: UInt16, pressed: Bool, isRepeat: Bool, ctrlModified: Bool) -> Bool {
 
         if isRepeat {
             // eat, eat, eat!
             return true
         }
 
-        let name = KeyCodeNames.virtualCodes[keycode] ?? "Btn"
+        var name = KeyCodeNames.virtualCodes[keycode] ?? "Btn"
+
+        if keycode == 59 || keycode == 62 {
+            // if this is Control
+            if !pressed {
+                // just in case <pressed=true, ctrl=true> followed by <pressed=false, ctrl=false>
+                // release modified keys when ctrl release
+                while let key = modifiedKeys.first {
+                    _ = handleKey(
+                        keycode: key,
+                        pressed: false, isRepeat: false,
+                        ctrlModified: true)
+                }
+            }
+        } else if ctrlModified && pressed {
+            name = "⌃" + name // "⌃" is not "^"
+            // Record pressed key
+            modifiedKeys.append(keycode)
+
+        } else if !pressed && modifiedKeys.contains(keycode) {
+            // just in case <pressed=true, ctrl=false> followed by <pressed=false, ctrl=true>
+            // does not modify on release if not recorded
+            name = "⌃" + name // "⌃" is not "^"
+            // unrecord released key
+            modifiedKeys.removeAll(where: {code in code == keycode})
+        }
+
         return ActionDispatcher.dispatch(key: name, pressed: pressed)
     }
 

--- a/PlayTools/Controls/Frontend/EventAdapter/Keyboard/Instances/TransparentKeyboardEventAdapter.swift
+++ b/PlayTools/Controls/Frontend/EventAdapter/Keyboard/Instances/TransparentKeyboardEventAdapter.swift
@@ -10,7 +10,7 @@ import Foundation
 // Keyboard events handler when keyboard mapping is off
 
 public class TransparentKeyboardEventAdapter: KeyboardEventAdapter {
-    public func handleKey(keycode: UInt16, pressed: Bool, isRepeat: Bool) -> Bool {
+    public func handleKey(keycode: UInt16, pressed: Bool, isRepeat: Bool, ctrlModified: Bool) -> Bool {
         // explicitly eat repeated Enter key
         isRepeat && keycode == 36
     }

--- a/PlayTools/Controls/Frontend/EventAdapter/Keyboard/KeyboardEventAdapter.swift
+++ b/PlayTools/Controls/Frontend/EventAdapter/Keyboard/KeyboardEventAdapter.swift
@@ -10,5 +10,5 @@ import Foundation
 // All keyboard events under any mode
 
 public protocol KeyboardEventAdapter: EventAdapter {
-    func handleKey(keycode: UInt16, pressed: Bool, isRepeat: Bool) -> Bool
+    func handleKey(keycode: UInt16, pressed: Bool, isRepeat: Bool, ctrlModified: Bool) -> Bool
 }

--- a/Plugin.swift
+++ b/Plugin.swift
@@ -23,7 +23,7 @@ public protocol Plugin: NSObjectProtocol {
     func warpCursor()
     func unhideCursor()
     func terminateApplication()
-    func setupKeyboard(keyboard: @escaping(UInt16, Bool, Bool) -> Bool,
+    func setupKeyboard(keyboard: @escaping(UInt16, Bool, Bool, Bool) -> Bool,
                        swapMode: @escaping() -> Bool)
     func setupMouseMoved(_ mouseMoved: @escaping(CGFloat, CGFloat) -> Bool)
     func setupMouseButton(left: Bool, right: Bool, _ consumed: @escaping(Int, Bool) -> Bool)


### PR DESCRIPTION
Implements #124 

<img width="595" alt="截屏2024-06-15 20 42 09" src="https://github.com/PlayCover/PlayTools/assets/16048758/2ed62bba-c67a-43ec-8f36-4e311c1d5661">


Managed to implement this without breaking keymap format compatibility, by prepending a `⌃` symbol before the key name to mark it a modifier combination.

As Control key is now used as a modifier key, it can't be mapped separately any more. But existing keymaps with Control key mapped can still use it.

## Limitations

Can only map `Button` type actions, this excludes `DraggableButton` and `Joystick`. It's because these two mainly rely on key code (instead of key name) to distinguish different keys. It's further because of the underlying keymap format, in which there are not enough fields for key name for these types.