### PR TITLE
Fix controller input lag or unresponsive in some games

### DIFF
--- a/PlayTools/Controls/PlayInput.swift
+++ b/PlayTools/Controls/PlayInput.swift
@@ -10,7 +10,15 @@ class PlayInput {
                                                qos: .userInteractive,
                                                autoreleaseFrequency: .workItem)
 
+    @objc func drainMainDispatchQueue() {
+        _dispatch_main_queue_callback_4CF(nil)
+    }
+
     func initialize() {
+        // drain the dispatch queue every frame for responding to GCController events
+        let displaylink = CADisplayLink(target: self, selector: #selector(drainMainDispatchQueue))
+        displaylink.add(to: .main, forMode: .common)
+
         if !PlaySettings.shared.keymapping {
             return
         }

--- a/PlayTools/PlayTools.h
+++ b/PlayTools/PlayTools.h
@@ -17,3 +17,7 @@ FOUNDATION_EXPORT const unsigned char PlayToolsVersionString[];
 #import "UIApplication+Private.h"
 #import "UIEvent+Private.h"
 #import "UITouch+Private.h"
+
+// This is the function that CFRunLoop calls to serve main dispatch queue
+// Used by PlayInput to manually drain the queue
+extern void _dispatch_main_queue_callback_4CF(void *);


### PR DESCRIPTION
Fixes Playcover/Playcover/issues/1550

The issue is basically the same as #83. Testing and analysis shows that some games rely on GameController APIs (which in turn relies on main dispatch queue) to process controller input. But main dispatch queue may not be served in time for some reason.

`CFRunLoop` of the main thread typically drains the main dispatch queue. It eventually calls `_dispatch_main_queue_callback_4CF()` to do its work. In PlayTools, by calling this function every frame, the input can be processed timely. This is done via the `CADisplayLink`, which is a timer that gets called every frame, originally designed for handling UI drawing routines.

With this fix, I have played ZZZ with an XBox controller on my M1 pro Macbook, with ProMotion on, low power mode on, keymapping on, game in fullscreen and game fps set to 120Hz, for 4 hours and didn't encounter any input lag or unresponsiveness.