### PR TITLE
Fix a crash in Unreal Engine games when system language is Chinese

### DIFF
--- a/PlayTools/PlayLoader.m
+++ b/PlayTools/PlayLoader.m
@@ -242,16 +242,8 @@ static void __attribute__((constructor)) initialize(void) {
     [PlayCover launch];
     
     if (ue_status == 0) {
-        NSURL* appFolder = [[NSBundle mainBundle] bundleURL];
-        NSArray* ueFiles = @[
-            [appFolder URLByAppendingPathComponent:@"ue4commandline.txt"],
-            [appFolder URLByAppendingPathComponent:@"uecommandline.txt"],
-        ];
-
-        for (NSURL* ueFile in ueFiles) {
-            if (!access([[ueFile path] cStringUsingEncoding:NSUTF8StringEncoding], F_OK)) {
-                ue_status = 2;
-            }
+        if (PlayInfo.isUnrealEngine) {
+            ue_status = 2;
         }
     }
     

--- a/PlayTools/Utils/PlayInfo.swift
+++ b/PlayTools/Utils/PlayInfo.swift
@@ -5,10 +5,23 @@
 
 import Foundation
 
-class PlayInfo {
+class PlayInfo: NSObject {
     static var isLauncherInstalled: Bool {
         return AKInterface.shared!
             .urlForApplicationWithBundleIdentifier("io.playcover.PlayCover") != nil
+    }
+
+    @objc static var isUnrealEngine: Bool {
+        let appFolder = Bundle.main.bundleURL
+        let ueFiles: [URL] = [
+            appFolder.appendingPathComponent("ue4commandline.txt"),
+            appFolder.appendingPathComponent("uecommandline.txt")
+        ]
+
+        for ueFile in ueFiles where FileManager.default.fileExists(atPath: ueFile.path) {
+            return true
+        }
+        return false
     }
 }
 


### PR DESCRIPTION
### Summary
Recently some Unreal Engine games started using the [Extended Virtual Addressing](https://developer.apple.com/documentation/bundleresources/entitlements/com.apple.developer.kernel.extended-virtual-addressing) feature. When this feature is enabled, Unreal Engine attempts to extract the Entitlement from the executable and checks whether it contains `com.apple.developer.kernel.extended-virtual-addressing`.
However, due to an issue in Unreal Engine’s code, it read **8 extra bytes**. These extra bytes cause a string decoding failure when the system language is set to Chinese, ultimately leading to a crash.

### Explanations
[FApplePlatformMemory.cpp](https://github.com/EpicGames/UnrealEngine/blob/release/Engine/Source/Runtime/Core/Private/Apple/ApplePlatformMemory.cpp#L874)
This function calls `FIOSPlatformMisc::IsEntitlementEnabled`.
``` cpp
bool FApplePlatformMemory::CanOverallocateVirtualMemory()
{
    static bool bHasExtendedVirtualAddressingEntitlement = FIOSPlatformMisc::IsEntitlementEnabled("com.apple.developer.kernel.extended-virtual-addressing");
    return bHasExtendedVirtualAddressingEntitlement;
}
```
<br/>

[FIOSPlatformMisc.cpp](https://github.com/EpicGames/UnrealEngine/blob/release/Engine/Source/Runtime/Core/Private/IOS/IOSPlatformMisc.cpp#L1519)
`EntitlementsData()` returns an empty string, but the `range` is nonzero, causing stringByReplacingOccurrencesOfString to crash with a Range out of bounds error.
``` objective-c
bool FIOSPlatformMisc::IsEntitlementEnabled(const char * EntitlementToCheck)
{
    NSString* TrueFlag = @"</key><true/>";
    NSString* EntitlementsToFind = [NSString stringWithFormat: @"%s%@" , EntitlementToCheck, TrueFlag];
    
    // Crash here!!!
    NSString* CleanedEntitlementData = [EntitlementsData() stringByReplacingOccurrencesOfString: @"\\s+" withString: @"" options: NSRegularExpressionSearch range: NSMakeRange(0, EntitlementsToFind.length)];

    // ...
}
```
<br/>

[IOSPlatformMisc.cpp](https://github.com/EpicGames/UnrealEngine/blob/release/Engine/Source/Runtime/Core/Private/IOS/IOSPlatformMisc.cpp#L1349)
It reads 8 extra bytes, which causes a decoding failure and returns an empty string. 
``` objective-c
typedef struct __Blob {
    uint32_t magic;
    uint32_t length;
    char data[];
} CS_GenericBlob;

extern NSString *EntitlementsData(void)
{
    // ...
	
    CS_GenericBlob blob;
    Count = fread(&blob, sizeof(CS_GenericBlob), 1, file);
	
    if (__builtin_bswap32(blob.magic) == 0xfade7171)
    {
        uint32 blobLength = ntohl(blob.length);
        char data[blobLength];
        fread(&data[0], sizeof(char) * blobLength, 1, file);
        NSString *stringFromData = [NSString stringWithFormat: @"%s", data];
        NSLog(@"%@", stringFromData);
        fclose(file);
        return stringFromData;
    }
	
    // ...
}
```

**Why has it read 8 extra bytes?**
The `blob.length` represents the total length of `CS_GenericBlob`, not the `data` array.
The actual length of the data array should be **blob.length - 8 bytes**.

**Why does it return an empty string?**
Expected data: `<plist>...</plist>`
Actual data read: `<plist>...</plist>\xfa\xde\x71\x72`
When we pass the data to stringWithFormat, it uses the encoding returned by `CFStringGetSystemEncoding()` to decode it. When the system language is set to Chinese, it will use `CFStringEncodingMacChineseSimp`, but the decoding fails, returning an empty string.

**Why doesn’t the crash happen on iOS?**
On iOS, `CFStringGetSystemEncoding()` always returns `0` regardless of the system language, so it works fine. On macOS, `CFStringGetSystemEncoding()` returns different values depending on the system language.
<br/>

### How to Fix
Hook the string replacement function. If the source string is empty, return immediately to prevent a Range out of bounds error.
<br/>