### PR TITLE
Fix file creation bug and fix UE_PATTERN initialization

### DIFF
--- a/PlayTools/PlayLoader.m
+++ b/PlayTools/PlayLoader.m
@@ -201,14 +201,14 @@ static char const* ue_fix_filename(char const* filename) {
 static int pt_open(char const* restrict filename, int oflag, ... ) {
     filename = ue_fix_filename(filename);
 
-    if (oflag == O_CREAT) {
+    if (oflag & O_CREAT) {
         int mod;
         va_list ap;
         va_start(ap, oflag);
         mod = va_arg(ap, int);
         va_end(ap);
 
-        return open(filename, O_CREAT, mod);
+        return open(filename, oflag, mod);
     }
 
     return open(filename, oflag);

--- a/PlayTools/PlayLoader.m
+++ b/PlayTools/PlayLoader.m
@@ -182,11 +182,14 @@ DYLD_INTERPOSE(pt_SecItemDelete, SecItemDelete)
 static uint8_t ue_status = 0;
 
 static char const* ue_fix_filename(char const* filename) {
-    static char UE_PATTERN[1024] = "//Users/";
-    getlogin_r(UE_PATTERN + 8, sizeof(UE_PATTERN) - 8);
-    
     char const* p = filename;
     if (ue_status == 2) {
+        static char* UE_PATTERN = NULL;
+        if (!UE_PATTERN) {
+            char const* username = [NSUserName() UTF8String];
+            asprintf(&UE_PATTERN, "//Users/%s", username);
+        }
+
         char const* last_p = p;
         while ((p = strstr(p, UE_PATTERN))) {
             last_p = ++p;


### PR DESCRIPTION
### File Creation Bug:
The `oflag` parameter in the `open()` function is a combination of multiple flags, so it should be handled using a bitwise operation (&) rather than a direct comparison (==).
This ensures files are created with the correct permissions. I encountered an issue where all files were being created with incorrect permissions (000) in Infinity Nikki.

### UE_PATTERN Initialization:
The `getlogin_r()` function is unreliable on macOS, it is recommended to use `getpwuid()` or `NSUserName()` to retrieve the username.
Additionally, the initialization of UE_PATTERN has been moved to the `ue_status == 2` branch to ensure it only affects Unreal Engine games.
