### PR TITLE
Fix menu not display on macOS 26 issue

### DIFF
--- a/PlayTools/Controls/MenuController.swift
+++ b/PlayTools/Controls/MenuController.swift
@@ -134,7 +134,7 @@ class MenuController {
             setupMenu(with: builder)
         }
     }
-    
+
     func setupMenu(with builder: UIMenuBuilder) {
         if Toucher.logEnabled {
             builder.insertSibling(MenuController.debuggingMenu(), afterMenu: .view)

--- a/PlayTools/Controls/MenuController.swift
+++ b/PlayTools/Controls/MenuController.swift
@@ -120,6 +120,22 @@ var keymappingSelectors = [#selector(UIApplication.switchEditorMode(_:)),
 
 class MenuController {
     init(with builder: UIMenuBuilder) {
+        if #available(iOS 26.0, *) {
+            // Delay to avoid error
+            // Cannot set a main menu system configuration while the main menu system is building.
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+                let configuration = UIMainMenuSystem.Configuration()
+                configuration.sidebarPreference = .included
+                UIMainMenuSystem.shared.setBuildConfiguration(configuration) { builder in
+                    self.setupMenu(with: builder)
+                }
+            }
+        } else {
+            setupMenu(with: builder)
+        }
+    }
+    
+    func setupMenu(with builder: UIMenuBuilder) {
         if Toucher.logEnabled {
             builder.insertSibling(MenuController.debuggingMenu(), afterMenu: .view)
         }


### PR DESCRIPTION
Use the new `UIMainMenuSystem` to configure the system menu to display the `Keymapping` menu.

Note:
The `UIMainMenuSystem` needs the macOS 26 Beta SDK. The fix is a temp patch and should not used for release. 
Please make a beta branch for the PR's target until OS Tahoe released.


<img width="500" alt="" src="https://github.com/user-attachments/assets/bbaf2d22-a2e5-482b-8dd9-70f2e9dc864a" />
