### PR TITLE
Fix microphone permission in certain games

### DIFF
--- a/PlayTools/PlaySettings.swift
+++ b/PlayTools/PlaySettings.swift
@@ -83,6 +83,8 @@ let settings = PlaySettings.shared
     @objc lazy var enableScrollWheel = settingsData.enableScrollWheel
 
     @objc lazy var hideTitleBar = settingsData.hideTitleBar
+
+    @objc lazy var checkMicPermissionSync = settingsData.checkMicPermissionSync
 }
 
 struct AppSettingsData: Codable {
@@ -108,4 +110,5 @@ struct AppSettingsData: Codable {
     var noKMOnInput = false
     var enableScrollWheel = true
     var hideTitleBar = false
+    var checkMicPermissionSync = false
 }


### PR DESCRIPTION
Some Tencent games report “microphone permission not granted” issues.
All these games use the same voice chat SDK [GVoice](https://gcloud.tencent.com/pages/documents/details.html?projectId=256&docId=6061), which relies on the following code:
``` objective-c
bool SomeClass::IsMicEnable() {
    bool bRet;
    [[AVAudioSession sharedInstance] requestRecordPermission:^(BOOL granted) {
         bRet = granted;
    }];
    return bRet;
}
```

<details>
<summary>More Details</summary>

Reverse engineering [CProcessingGraph.o](https://github.com/user-attachments/files/21413113/CProcessingGraph.o.zip) from `libGCloudVoice.a`:

``` objective-c
bool ApolloTVE::CProcessingGraph::CheckProcess() {
    char model[128];
    memset(model, 0, sizeof(model));
    size_t size;
    sysctlbyname("hw.model", NULL, &size, NULL, 0);
    sysctlbyname("hw.model", model, &size, NULL, 0);
    this->m_bM1Process = [[NSString stringWithCString:model] containsString:@"Mac"];
}

bool ApolloTVE::CProcessingGraph::IsMicEnable() {
    bool bRet;
    if (this->m_bM1Process) {
         int64_t TimeMs = GetTimeMs();
         bool bWait = true;
         while (bWait) {
             if (GetTimeMs() - TimeMs > 100) {
                 bWait = false;
             }
             [[AVAudioSession sharedInstance] requestRecordPermission:^(BOOL granted) {
                   bRet = granted;
                   bWait = false;
             }];
         }
    }
    else {
        [[AVAudioSession sharedInstance] requestRecordPermission:^(BOOL granted) {
             bRet = granted;
        }];
    }
    return bRet;
}
```
</details>

It’s clear that this code expects `requestRecordPermission:` to return the result immediately, as if it were a synchronous call.
This might work on iOS, but on macOS, there’s a slight delay before the result is returned.

How to Fix:
Hook `requestRecordPermission:` to return the result immediately when permission is already granted.
