### PR TITLE
Fix excessive CPU usage caused by motion sensor updates

### DIFF
--- a/PlayTools/PlaySettings.swift
+++ b/PlayTools/PlaySettings.swift
@@ -85,6 +85,8 @@ let settings = PlaySettings.shared
     @objc lazy var hideTitleBar = settingsData.hideTitleBar
 
     @objc lazy var checkMicPermissionSync = settingsData.checkMicPermissionSync
+
+    @objc lazy var limitMotionUpdateFrequency = settingsData.limitMotionUpdateFrequency
 }
 
 struct AppSettingsData: Codable {
@@ -111,4 +113,5 @@ struct AppSettingsData: Codable {
     var enableScrollWheel = true
     var hideTitleBar = false
     var checkMicPermissionSync = false
+    var limitMotionUpdateFrequency = false
 }


### PR DESCRIPTION
It was confirmed that some games suffer from excessive CPU usage.
This is caused by `CMMotionManager` setting the default update interval to 0, which results in extremely frequent updates.

You can verify the update frequency using the following code:
``` objective-c
// NSObject+Swizzle.mm

@implementation NSObject (Swizzle)
- (void)hook_UINSVirtualMotionDevice_scanAccelerometer {
    NSLog(@"[PlayTools] hook_UINSVirtualMotionDevice_scanAccelerometer");
    [self hook_UINSVirtualMotionDevice_scanAccelerometer];
}
@end

@implementation PTSwizzleLoader
+ (void)load {
    [objc_getClass("UINSVirtualMotionDevice") swizzleInstanceMethod:NSSelectorFromString(@"_scanAccelerometer") withMethod:@selector(hook_UINSVirtualMotionDevice_scanAccelerometer)];
}
@end
```

<br/>

As shown below, the actual update interval can be as short as 0.0001 seconds.
<img width="727" height="174" alt="Screenshot" src="https://github.com/user-attachments/assets/7436e06f-0327-44b2-9076-34af007bae2c" />

Some other games explicitly set the update interval to 0.01 or 0.02 seconds via `[CMMotionManager setAccelerometerUpdateInterval:]`, so they do not have excessive CPU usage.

**How to Fix**
Hook `[CMMotionManager init]` and change the default update interval to 0.01 seconds.
