### PR TITLE
Fix: app freeze or crash when click close button

### DIFF
--- a/PlayTools/PlayCover.swift
+++ b/PlayTools/PlayCover.swift
@@ -68,6 +68,7 @@ public class PlayCover: NSObject {
                 // Some apps will freeze or crash when click close button if we send willTerminateNotification.
                 // The developer documentation says this is a "may be called method", so it can be safely skipped.
                 // https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1623111-applicationwillterminate
+                // swiftlint:disable:previous line_length
 //                NotificationCenter.default.post(name: UIApplication.willTerminateNotification,
 //                                                object: UIApplication.shared)
                 DispatchQueue.main.async(execute: AKInterface.shared!.terminateApplication)

--- a/PlayTools/PlayCover.swift
+++ b/PlayTools/PlayCover.swift
@@ -59,9 +59,17 @@ public class PlayCover: NSObject {
                 // There is an expiration handler, but idk how to invoke it. Skip for now.
 
                 // Step 3: Terminate
+                for scene in UIApplication.shared.connectedScenes {
+                    scene.delegate?.sceneDidDisconnect?(scene)
+                    NotificationCenter.default.post(name: UIScene.didDisconnectNotification,
+                                                    object: scene)
+                }
                 UIApplication.shared.delegate?.applicationWillTerminate?(UIApplication.shared)
-                NotificationCenter.default.post(name: UIApplication.willTerminateNotification,
-                                                object: UIApplication.shared)
+                // Some apps will freeze or crash when click close button if we send willTerminateNotification.
+                // The developer documentation says this is a "may be called method", so it can be safely skipped.
+                // https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1623111-applicationwillterminate
+//                NotificationCenter.default.post(name: UIApplication.willTerminateNotification,
+//                                                object: UIApplication.shared)
                 DispatchQueue.main.async(execute: AKInterface.shared!.terminateApplication)
 
                 // Step 3.5: End BGTask


### PR DESCRIPTION
Some apps will freeze or crash when click close button if we send willTerminateNotification. The developer documentation says this is a "may be called method", so it can be safely skipped.
https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1623111-applicationwillterminate

Related PR: https://github.com/PlayCover/PlayTools/pull/136