### PR TITLE
Fix mouse click conflicts by disabling built-in mouse support

### DIFF
--- a/PlayTools/PlaySettings.swift
+++ b/PlayTools/PlaySettings.swift
@@ -87,6 +87,8 @@ let settings = PlaySettings.shared
     @objc lazy var checkMicPermissionSync = settingsData.checkMicPermissionSync
 
     @objc lazy var limitMotionUpdateFrequency = settingsData.limitMotionUpdateFrequency
+
+    @objc lazy var disableBuiltinMouse = settingsData.disableBuiltinMouse
 }
 
 struct AppSettingsData: Codable {
@@ -114,4 +116,5 @@ struct AppSettingsData: Codable {
     var hideTitleBar = false
     var checkMicPermissionSync = false
     var limitMotionUpdateFrequency = false
+    var disableBuiltinMouse = false
 }


### PR DESCRIPTION
Many Unreal Engine games receive both touch and mouse inputs simultaneously, but they do not handle the mouse inputs properly, which leads to click issues.
To resolve these conflicts, we need to disable the app’s built-in mouse support.
<br/>

**Related Issues:**
1. https://github.com/PlayCover/PlayCover/issues/1587
All the games mentioned in this issue are made with Unreal Engine.

2. https://github.com/PlayCover/PlayCover/issues/1755
     > The "Accept" user agreement button and "Login" button can only be triggered by a Trackpad tap but not a mouse click (not a MagicMouse).
<br/>

**Additional Note:**
`swizzleClassMethod:withMethod` is copied from `PlayShadow.m`.
