### PR TITLE
feat(events): implement scroll wheel interception and key mapping

### DIFF
--- a/PlayTools/Controls/ActionDispatcher.swift
+++ b/PlayTools/Controls/ActionDispatcher.swift
@@ -202,6 +202,18 @@ public class ActionDispatcher {
         return mapped
     }
 
+    static public func dispatchClick(key: String) -> Bool {
+        guard buttonHandlers[key] != nil else {
+            return false
+        }
+        _ = dispatch(key: key, pressed: true)
+        // 延迟 30ms 自动释放，模拟一次物理点击
+        PlayInput.touchQueue.asyncAfter(deadline: .now() + 0.03, qos: .userInteractive, execute: {
+            _ = dispatch(key: key, pressed: false)
+        })
+        return true
+    }
+
     static public func dispatch(key: String, valueX: CGFloat, valueY: CGFloat) -> Bool {
         for priority in 0..<priorityCount {
             if let handler = directionPadHandlers[priority].first(where: { handler in

--- a/PlayTools/Controls/Frontend/ControlMode.swift
+++ b/PlayTools/Controls/Frontend/ControlMode.swift
@@ -41,7 +41,8 @@ public class ControlMode: Equatable {
 
         setupGameController()
         setupKeyboard()
-        if PlaySettings.shared.enableScrollWheel {
+        // Initialize scroll wheel if either zoom or keymapping is enabled
+        if PlaySettings.shared.enableScrollWheelZoom || PlaySettings.shared.enableScrollWheelMapping {
             setupScrollWheel()
         }
 

--- a/PlayTools/Controls/Frontend/EventAdapter/Mouse/Instances/CameraControlMouseEventAdapter.swift
+++ b/PlayTools/Controls/Frontend/EventAdapter/Mouse/Instances/CameraControlMouseEventAdapter.swift
@@ -11,9 +11,28 @@ import Foundation
 
 public class CameraControlMouseEventAdapter: MouseEventAdapter {
     public func handleScrollWheel(deltaX: CGFloat, deltaY: CGFloat) -> Bool {
-        _ = ActionDispatcher.dispatch(key: KeyCodeNames.scrollWheelScale, valueX: deltaX, valueY: deltaY)
-        // I dont know why but this is the logic before the refactor.
-        // Might be a mistake but keeping it for now
+        // Priority 1: Keymapping. If enabled and triggered, consume the event.
+        if PlaySettings.shared.enableScrollWheelMapping {
+            let threshold: CGFloat = 0.5
+            var handled = false
+            if deltaY > threshold {
+                handled = ActionDispatcher.dispatchClick(key: "ScrU")
+            } else if deltaY < -threshold {
+                handled = ActionDispatcher.dispatchClick(key: "ScrD")
+            }
+            
+            // If mapping was triggered, return true to consume the event
+            if handled {
+                return true
+            }
+        }
+
+        // Priority 2: Zoom/Scale logic.
+        if PlaySettings.shared.enableScrollWheelZoom {
+            _ = ActionDispatcher.dispatch(key: KeyCodeNames.scrollWheelScale, valueX: deltaX, valueY: deltaY)
+            return true
+        }
+        
         return true
     }
 

--- a/PlayTools/Controls/Frontend/EventAdapter/Mouse/Instances/EditorMouseEventAdapter.swift
+++ b/PlayTools/Controls/Frontend/EventAdapter/Mouse/Instances/EditorMouseEventAdapter.swift
@@ -36,8 +36,21 @@ public class EditorMouseEventAdapter: MouseEventAdapter {
         return true
     }
 
+    private static var lastScrollTime: TimeInterval = 0
+
     public func handleScrollWheel(deltaX: CGFloat, deltaY: CGFloat) -> Bool {
-        false
+        let currentTime = ProcessInfo.processInfo.systemUptime
+        // 阈值判断：deltaY 绝对值需大于 0.2 以防极小干扰，且 0.3s 内不重复触发
+        if abs(deltaY) > 0.2 && (currentTime - EditorMouseEventAdapter.lastScrollTime) > 0.3 {
+            EditorMouseEventAdapter.lastScrollTime = currentTime
+            let keyCode = deltaY > 0 ? -100 : -101
+            DispatchQueue.main.async(qos: .userInteractive, execute: {
+                EditorController.shared.setKey(keyCode)
+                Toucher.writeLog(logMessage: "mouse wheel editor set: \(keyCode)")
+            })
+            return true
+        }
+        return false
     }
 
     public func handleMove(deltaX: CGFloat, deltaY: CGFloat) -> Bool {

--- a/PlayTools/Controls/Frontend/EventAdapter/Mouse/Instances/TouchscreenMouseEventAdapter.swift
+++ b/PlayTools/Controls/Frontend/EventAdapter/Mouse/Instances/TouchscreenMouseEventAdapter.swift
@@ -50,9 +50,30 @@ public class TouchscreenMouseEventAdapter: MouseEventAdapter {
     }
 
     public func handleScrollWheel(deltaX: CGFloat, deltaY: CGFloat) -> Bool {
-        _ = ActionDispatcher.dispatch(key: KeyCodeNames.scrollWheelDrag, valueX: deltaX, valueY: deltaY)
-        // I dont know why but this is the logic before the refactor.
-        // Might be a mistake but keeping it for now
+        // Priority 1: Keymapping. If enabled and triggered, consume the event.
+        if PlaySettings.shared.enableScrollWheelMapping {
+            let threshold: CGFloat = 0.5
+            var handled = false
+            if deltaY > threshold {
+                handled = ActionDispatcher.dispatchClick(key: "ScrU")
+            } else if deltaY < -threshold {
+                handled = ActionDispatcher.dispatchClick(key: "ScrD")
+            }
+            
+            // If mapping was triggered, return true to consume the event
+            // and prevent it from reaching any other logic (like zoom).
+            if handled {
+                return true
+            }
+        }
+
+        // Priority 2: Zoom logic.
+        if PlaySettings.shared.enableScrollWheelZoom {
+            _ = ActionDispatcher.dispatch(key: KeyCodeNames.scrollWheelDrag, valueX: deltaX, valueY: deltaY)
+            // Generally return true after processing to keep behavior consistent
+            return true
+        }
+        
         return false
     }
 

--- a/PlayTools/Keymap/KeyCodeNames.swift
+++ b/PlayTools/Keymap/KeyCodeNames.swift
@@ -30,6 +30,8 @@ class KeyCodeNames {
     -1: "LMB",
     -2: "RMB",
     -3: "MMB",
+    -100: "ScrU",
+    -101: "ScrD",
     41: "Esc",
     44: "Spc",
     225: "Lshft",

--- a/PlayTools/PlaySettings.swift
+++ b/PlayTools/PlaySettings.swift
@@ -82,7 +82,8 @@ let settings = PlaySettings.shared
 
     @objc lazy var noKMOnInput = settingsData.noKMOnInput
 
-    @objc lazy var enableScrollWheel = settingsData.enableScrollWheel
+    @objc lazy var enableScrollWheelZoom = settingsData.enableScrollWheelZoom
+    @objc lazy var enableScrollWheelMapping = settingsData.enableScrollWheelMapping
 
     @objc lazy var hideTitleBar = settingsData.hideTitleBar
 
@@ -118,7 +119,8 @@ struct AppSettingsData: Codable {
     var windowFixMethod = 0
     var rootWorkDir = true
     var noKMOnInput = false
-    var enableScrollWheel = true
+    var enableScrollWheelZoom = true // Original zoom logic
+    var enableScrollWheelMapping = false // New keymapping logic
     var hideTitleBar = false
     var floatingWindow = false
     var checkMicPermissionSync = false


### PR DESCRIPTION
## Overview
This PR updates the HID event adapters to support mapping mouse scroll wheel rotations to virtual key presses, complementing the UI changes in PlayCover.

## Key Changes
- **[Interception] Event Interception**: Modified `TouchscreenMouseEventAdapter` and `CameraControlMouseEventAdapter` to check for `enableScrollWheelMapping`.
- **[Logic] Scroll-to-Key Logic**: When mapping is enabled, scroll wheel events are intercepted and converted into `ScrU` (scroll up) or `ScrD` (scroll down) virtual keys.
- **[Safety] Event Consumption**: Ensuring that intercepted scroll events are fully consumed when mapping is active to prevent unintended zoom actions in-game.

> [!IMPORTANT]
> **Dependency Note**: This PR is designed to work in tandem with the updated setting schema in **PlayCover**.
> **Compatibility Warning**: As the setting key has been migrated from `enableScrollWheel` to `enableScrollWheelZoom`, this version of PlayTools will **not be compatible** with older versions of PlayCover. Please ensure both PRs are merged at the same time to maintain functional integrity.