### PR TITLE
chore: update swordrpc

### DIFF
--- a/PlayTools.xcodeproj/project.pbxproj
+++ b/PlayTools.xcodeproj/project.pbxproj
@@ -1111,8 +1111,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/PlayCover/SwordRPC";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 1.2.0;
+				kind = exactVersion;
+				version = 1.2.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/PlayTools.xcodeproj/project.pbxproj
+++ b/PlayTools.xcodeproj/project.pbxproj
@@ -1111,8 +1111,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/PlayCover/SwordRPC";
 			requirement = {
-				branch = main;
-				kind = branch;
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.2.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/PlayTools/DiscordActivity/DiscordIPC.swift
+++ b/PlayTools/DiscordActivity/DiscordIPC.swift
@@ -41,6 +41,9 @@ class DiscordIPC {
             if custom.details.count == 1 { custom.details += " " }
             activity.details = custom.details
         }
+        activity.detailsUrl = "https://github.com/PlayCover/PlayCover/releases"
+
+        activity.statusDisplayType = .details
 
         let poweredStr = "Powered by PlayCover"
         if custom.state.isEmpty {
@@ -51,6 +54,7 @@ class DiscordIPC {
             activity.assets.smallText = poweredStr
             activity.assets.largeText = poweredStr
         }
+        activity.stateUrl = "https://github.com/PlayCover/PlayCover/releases"
 
         let logo = "https://raw.githubusercontent.com/PlayCover/PlaySite/master/src/assets/square-logo.png"
         if custom.image.isEmpty {
@@ -69,11 +73,6 @@ class DiscordIPC {
         }
 
         activity.timestamps.start = Date()
-
-        activity.buttons = [
-            RichPresence.Button(label: "Download PlayCover",
-                                url: "https://github.com/PlayCover/PlayCover/releases")
-        ]
 
         return activity
     }


### PR DESCRIPTION
Depends on https://github.com/PlayCover/SwordRPC/pull/3, requiring a version tag of 1.2.0 after it gets merged.

Note: This pull request removes the "Download PlayCover" button in favor of adding the download url to the details and state hyperlink. Along with that, this will also set the status display to be the app the user is playing by default.