### PR TITLE
Fixes IOHIDEvent/UITouch phase mismatch that causes some games

### DIFF
--- a/PlayTools/Controls/PTFakeTouch/Additions/IOHIDEvent+KIF.m
+++ b/PlayTools/Controls/PTFakeTouch/Additions/IOHIDEvent+KIF.m
@@ -142,21 +142,21 @@ IOHIDEventRef kif_IOHIDEventWithTouches(NSArray *touches) {
     AbsoluteTime timeStamp;
     timeStamp.hi = (UInt32)(abTime >> 32);
     timeStamp.lo = (UInt32)(abTime);
-    IOHIDEventRef handEvent = IOHIDEventCreateDigitizerEvent(kCFAllocatorDefault,
-                                                             timeStamp,
-                                                             kIOHIDDigitizerTransducerTypeHand,
-                                                             0,
-                                                             0,
-                                                             kIOHIDDigitizerEventTouch,
-                                                             0,
-                                                             0,
-                                                             0,
-                                                             0,
-                                                             0,
-                                                             0,
-                                                             0,
-                                                             true,
-                                                             0);
+    IOHIDEventRef handEvent = IOHIDEventCreateDigitizerEvent(kCFAllocatorDefault, // allocator 内存分配器
+                                                             timeStamp, // timestamp 时间戳
+                                                             kIOHIDDigitizerTransducerTypeHand, // type
+                                                             0, // index
+                                                             0, // identity
+                                                             kIOHIDDigitizerEventTouch, // eventMask
+                                                             0, // buttonMask
+                                                             0, // x
+                                                             0, // y
+                                                             0, // z
+                                                             0, // tipPressure
+                                                             0, // barrelPressure
+                                                             0, // range
+                                                             true, // touch
+                                                             0); // options
     IOHIDEventSetIntegerValue(handEvent, kIOHIDEventFieldDigitizerIsDisplayIntegrated, true);
 
     for (UITouch *touch in touches) {
@@ -191,24 +191,24 @@ IOHIDEventRef kif_IOHIDEventWithTouches(NSArray *touches) {
         fingerTimestamp.hi = (UInt32)(fingerTime >> 32);
         fingerTimestamp.lo = (UInt32)(fingerTime);
 
-        IOHIDEventRef fingerEvent = IOHIDEventCreateDigitizerFingerEventWithQuality(kCFAllocatorDefault,
-                                                                                    fingerTimestamp,
-                                                                                    (UInt32)[touches indexOfObject:touch] + 1,
-                                                                                    2,
-                                                                                    eventMask,
-                                                                                    (IOHIDFloat)touchLocation.x,
-                                                                                    (IOHIDFloat)touchLocation.y,
-                                                                                    0.0,
-                                                                                    0,
-                                                                                    0,
-                                                                                    5.0,
-                                                                                    5.0,
-                                                                                    1.0,
-                                                                                    1.0,
-                                                                                    1.0,
-                                                                                    (IOHIDFloat)isTouching,
-                                                                                    (IOHIDFloat)isTouching,
-                                                                                    0);
+        IOHIDEventRef fingerEvent = IOHIDEventCreateDigitizerFingerEventWithQuality(kCFAllocatorDefault, // allocator
+                                                                                    timeStamp, // timestamp
+                                                                                    (UInt32)[touches indexOfObject:touch] + 1, //index
+                                                                                    2, // identity
+                                                                                    eventMask, // eventMask
+                                                                                    (IOHIDFloat)touchLocation.x, // x
+                                                                                    (IOHIDFloat)touchLocation.y, // y
+                                                                                    0.0, // z
+                                                                                    0, // tipPressure
+                                                                                    0, // twist
+                                                                                    5.0, // minor radius
+                                                                                    5.0, // major radius
+                                                                                    1.0, // quality
+                                                                                    1.0, // density
+                                                                                    1.0, // irregularity
+                                                                                    (IOHIDFloat)isTouching, // range
+                                                                                    (IOHIDFloat)isTouching, // touch
+                                                                                    0); // options
         IOHIDEventSetIntegerValue(fingerEvent, kIOHIDEventFieldDigitizerIsDisplayIntegrated, 1);
         IOHIDEventAppendEvent(handEvent, fingerEvent);
         CFRelease(fingerEvent);

--- a/PlayTools/Controls/PTFakeTouch/Additions/IOHIDEvent+KIF.m
+++ b/PlayTools/Controls/PTFakeTouch/Additions/IOHIDEvent+KIF.m
@@ -142,45 +142,73 @@ IOHIDEventRef kif_IOHIDEventWithTouches(NSArray *touches) {
     AbsoluteTime timeStamp;
     timeStamp.hi = (UInt32)(abTime >> 32);
     timeStamp.lo = (UInt32)(abTime);
-    IOHIDEventRef handEvent = IOHIDEventCreateDigitizerEvent(kCFAllocatorDefault, // allocator 内存分配器
-                                                             timeStamp, // timestamp 时间戳
-                                                             kIOHIDDigitizerTransducerTypeHand, // type
-                                                             0, // index
-                                                             0, // identity
-                                                             kIOHIDDigitizerEventTouch, // eventMask
-                                                             0, // buttonMask
-                                                             0, // x
-                                                             0, // y
-                                                             0, // z
-                                                             0, // tipPressure
-                                                             0, // barrelPressure
-                                                             0, // range
-                                                             true, // touch
-                                                             0); // options
+    IOHIDEventRef handEvent = IOHIDEventCreateDigitizerEvent(kCFAllocatorDefault,
+                                                             timeStamp,
+                                                             kIOHIDDigitizerTransducerTypeHand,
+                                                             0,
+                                                             0,
+                                                             kIOHIDDigitizerEventTouch,
+                                                             0,
+                                                             0,
+                                                             0,
+                                                             0,
+                                                             0,
+                                                             0,
+                                                             0,
+                                                             true,
+                                                             0);
     IOHIDEventSetIntegerValue(handEvent, kIOHIDEventFieldDigitizerIsDisplayIntegrated, true);
 
     for (UITouch *touch in touches) {
-        uint32_t eventMask = (touch.phase == UITouchPhaseMoved) ? kIOHIDDigitizerEventPosition : (kIOHIDDigitizerEventRange | kIOHIDDigitizerEventTouch);
-        uint32_t isTouching = (touch.phase == UITouchPhaseEnded) ? 0 : 1;
+        // Set eventMask and touch/range state based on actual touch phase.
+        // These must accurately reflect the UITouch.phase so that game-side
+        // validation (e.g. Tencent anti-automation) does not flag the IO HID
+        // event as inconsistent with the UIKit touch state.
+        uint32_t eventMask;
+        uint32_t isTouching;
+        switch (touch.phase) {
+            case UITouchPhaseMoved:
+                eventMask = kIOHIDDigitizerEventPosition;
+                isTouching = 1;
+                break;
+            case UITouchPhaseEnded:
+            case UITouchPhaseCancelled:
+                eventMask = kIOHIDDigitizerEventTouch;
+                isTouching = 0;
+                break;
+            default: // Began / Stationary
+                eventMask = kIOHIDDigitizerEventRange | kIOHIDDigitizerEventTouch;
+                isTouching = 1;
+                break;
+        }
+
         CGPoint touchLocation = [touch locationInView:touch.window];
-        IOHIDEventRef fingerEvent = IOHIDEventCreateDigitizerFingerEventWithQuality(kCFAllocatorDefault, // allocator
-                                                                                    timeStamp, // timestamp
-                                                                                    (UInt32)[touches indexOfObject:touch] + 1, //index
-                                                                                    2, // identity
-                                                                                    eventMask, // eventMask
-                                                                                    (IOHIDFloat)touchLocation.x, // x
-                                                                                    (IOHIDFloat)touchLocation.y, // y
-                                                                                    0.0, // z
-                                                                                    0, // tipPressure
-                                                                                    0, // twist
-                                                                                    5.0, // minor radius
-                                                                                    5.0, // major radius
-                                                                                    1.0, // quality
-                                                                                    1.0, // density
-                                                                                    1.0, // irregularity
-                                                                                    (IOHIDFloat)isTouching, // range
-                                                                                    (IOHIDFloat)isTouching, // touch
-                                                                                    0); // options
+
+        // Each finger gets its own timestamp for more realistic HID events.
+        // Real multi-touch hardware fires independent events per finger.
+        uint64_t fingerTime = mach_absolute_time();
+        AbsoluteTime fingerTimestamp;
+        fingerTimestamp.hi = (UInt32)(fingerTime >> 32);
+        fingerTimestamp.lo = (UInt32)(fingerTime);
+
+        IOHIDEventRef fingerEvent = IOHIDEventCreateDigitizerFingerEventWithQuality(kCFAllocatorDefault,
+                                                                                    fingerTimestamp,
+                                                                                    (UInt32)[touches indexOfObject:touch] + 1,
+                                                                                    2,
+                                                                                    eventMask,
+                                                                                    (IOHIDFloat)touchLocation.x,
+                                                                                    (IOHIDFloat)touchLocation.y,
+                                                                                    0.0,
+                                                                                    0,
+                                                                                    0,
+                                                                                    5.0,
+                                                                                    5.0,
+                                                                                    1.0,
+                                                                                    1.0,
+                                                                                    1.0,
+                                                                                    (IOHIDFloat)isTouching,
+                                                                                    (IOHIDFloat)isTouching,
+                                                                                    0);
         IOHIDEventSetIntegerValue(fingerEvent, kIOHIDEventFieldDigitizerIsDisplayIntegrated, 1);
         IOHIDEventAppendEvent(handEvent, fingerEvent);
         CFRelease(fingerEvent);

--- a/PlayTools/Controls/PTFakeTouch/Additions/IOHIDEvent+KIF.m
+++ b/PlayTools/Controls/PTFakeTouch/Additions/IOHIDEvent+KIF.m
@@ -192,7 +192,7 @@ IOHIDEventRef kif_IOHIDEventWithTouches(NSArray *touches) {
         fingerTimestamp.lo = (UInt32)(fingerTime);
 
         IOHIDEventRef fingerEvent = IOHIDEventCreateDigitizerFingerEventWithQuality(kCFAllocatorDefault, // allocator
-                                                                                    timeStamp, // timestamp
+                                                                                    fingerTimestamp, // finger timestamp
                                                                                     (UInt32)[touches indexOfObject:touch] + 1, //index
                                                                                     2, // identity
                                                                                     eventMask, // eventMask

--- a/PlayTools/Controls/PTFakeTouch/Additions/UITouch-KIFAdditions.m
+++ b/PlayTools/Controls/PTFakeTouch/Additions/UITouch-KIFAdditions.m
@@ -95,6 +95,10 @@
     //DLog(@"setPhaseAndUpdateTimestamp : %ld",(long)phase);
     [self setTimestamp: [[NSProcessInfo processInfo] systemUptime]];
     [self setPhase:phase];
+    // Update the IOHIDEvent to match the new phase.
+    // Some games validate IOHIDEvent.eventMask against UITouch.phase,
+    // so keeping them in sync is critical for fake touch acceptance.
+    [self kif_setHidEvent];
 }
 
 - (void)kif_setHidEvent {


### PR DESCRIPTION
- Rebuild IOHIDEvent in setPhaseAndUpdateTimestamp: so eventMask stays in sync with UITouch.phase (was only set on touch creation)
- Fix kif_IOHIDEventWithTouches eventMask for ended/cancelled phases
- Use per-finger timestamps for more realistic HID events

Some games validate that IOHIDEvent properties match the current UITouch phase. Without this fix, moved/ended touches carry a stale began-phase IOHIDEvent, triggering detection.