### PR TITLE
fix: ignore Unity keyboard initialization error

### DIFF
--- a/PlayTools/Controls/PTFakeTouch/NSObject+Swizzle.m
+++ b/PlayTools/Controls/PTFakeTouch/NSObject+Swizzle.m
@@ -201,6 +201,15 @@ __attribute__((visibility("hidden")))
     return @[];
 }
 
++ (void)hook_Unity_KeyboardDelegate_Initialize {
+    @try {
+        [self hook_Unity_KeyboardDelegate_Initialize];
+    }
+    @catch (NSException *exception) {
+        NSLog(@"Caught exception: %@, reason: %@", exception.name, exception.reason);
+    }
+}
+
 // Hook for UIUserInterfaceIdiom
 
 // - (long long) hook_userInterfaceIdiom {
@@ -353,6 +362,13 @@ bool menuWasCreated = false;
         [objc_getClass("GCMouse") swizzleClassMethod:@selector(current) withMethod:@selector(hook_GCMouse_current)];
         [objc_getClass("GCMouse") swizzleClassMethod:@selector(mice) withMethod:@selector(hook_GCMouse_mice)];
     }
+
+    // Delay a frame to wait for some frameworks (such as UnityFramework) to load
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 0.01 * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
+        if ([[PlaySettings shared] ignoreUnityKeyboardInitializationError]) {
+            [objc_getClass("KeyboardDelegate") swizzleClassMethod:NSSelectorFromString(@"Initialize") withMethod:@selector(hook_Unity_KeyboardDelegate_Initialize)];
+        }
+    });
 }
 
 @end

--- a/PlayTools/PlaySettings.swift
+++ b/PlayTools/PlaySettings.swift
@@ -97,6 +97,8 @@ let settings = PlaySettings.shared
     @objc lazy var disableBuiltinMouse = settingsData.disableBuiltinMouse
 
     @objc lazy var blockSleepSpamming = settingsData.blockSleepSpamming
+
+    @objc lazy var ignoreUnityKeyboardInitializationError = settingsData.ignoreUnityKeyboardInitializationError
 }
 
 struct AppSettingsData: Codable {
@@ -131,4 +133,5 @@ struct AppSettingsData: Codable {
     var resizableAspectRatioWidth = 0
     var resizableAspectRatioHeight = 0
     var blockSleepSpamming = false
+    var ignoreUnityKeyboardInitializationError = false
 }


### PR DESCRIPTION
## Summary

Some Unity games crash on startup with the following assertion failure:

```
[KeyboardDelegate Initialize] called after creating keyboard
```

This PR adds an option to suppress the assertion and allow affected games to continue running.

## Related Code
``` objective-c
@implementation KeyboardDelegate
+ (void)Initialize
{
    NSAssert(_keyboard == nil, @"[KeyboardDelegate Initialize] called after creating keyboard");
    if (!_keyboard)
        _keyboard = [[KeyboardDelegate alloc] init];
}

+ (KeyboardDelegate*)Instance
{
    if (!_keyboard)
        _keyboard = [[KeyboardDelegate alloc] init];
    return _keyboard;
}
@end
```

``` objective-c
@implementation UnityView
- (NSArray*)keyCommands
{
    if ([[KeyboardDelegate Instance] status] == Visible)
        return nil;
	// ...
}
@end
```

``` objective-c
@implementation _UIMainMenuSystem
- (void)_setupMainSystemObservations {
	if ([[NSProcessInfo processInfo] isiOSAppOnMac]) {
	    [[NSNotificationCenter defaultCenter] addObserverForName:@"_UIWindowDidBecomeApplicationKeyNotification"
	                                                      object:nil
	                                                       queue:nil
	                                                  usingBlock:^(NSNotification *notification) {
	        // Collect key commands ...
	    }];
	}	
}
@end
```

## Explanation
By default, Unity calls `initUnityWithApplication:` during `application:didFinishLaunchingWithOptions:`.

```
application:didFinishLaunchingWithOptions: 
└─ [UnityAppController initUnityWithApplication:]  
   ├─ [UnityAppController createUnityView]
   ├─ [UIWindow makeKeyAndVisible]
   └─ [KeyboardDelegate Initialize] 
```

However, some games defer `initUnityWithApplication:` until `applicationDidBecomeActive:`.<br/>In this case, `[KeyboardDelegate Instance]` is called before `[KeyboardDelegate Initialize]`, which triggers the assertion failure.

```
applicationDidBecomeActive: 
└─ [UnityAppController initUnityWithApplication:]
   ├─ [UnityAppController createUnityView]
   ├─ [UIWindow makeKeyAndVisible]
   │  └─ Post _UIWindowDidBecomeApplicationKeyNotification
   │     └─ _UIMainMenuSystem
   │        └─ [UnityView keyCommands]
   │           └─ [KeyboardDelegate Instance]
   └─ [KeyboardDelegate Initialize]  ← Assertion failure 
```

Apparently it is an issue with the game itself, and there is nothing PlayCover can do.

Fortunately, this assertion failure does not affect gameplay, so the simplest solution is to ignore the assertion.


## Testing

For a quick test, check [this game](https://decrypt.day/app/id6480398822) (less than 100MB).
<br/>
