### PR TITLE
fix: add missing privacy usage descriptions to Info.plist

### DIFF
--- a/PlayTools/Info.plist
+++ b/PlayTools/Info.plist
@@ -18,5 +18,11 @@
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSAppleMusicUsageDescription</key>
+	<string>This app requires access to your music library to function properly.</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>This app requires microphone access for voice features.</string>
+	<key>com.apple.security.device.audio-input</key>
+	<false/>
 </dict>
 </plist>


### PR DESCRIPTION
## Changes

Add three missing entries to Info.plist:

### NSAppleMusicUsageDescription
Prevents crash on launch when an Apple Music subscription is active on the host device. Without this key, the system kills the process with TCC error 0 when the app attempts to access the media library.

Fixes #169

### NSMicrophoneUsageDescription + com.apple.security.device.audio-input
Enable microphone access for apps that require it. The NSMicrophoneUsageDescription provides the privacy prompt string, and com.apple.security.device.audio-input is the entitlement that grants the sandbox exception.

Fixes #170
