### PR TITLE
fix: improve SecKeyGeneratePair implementation in PlayChain

### DIFF
--- a/PlayTools/MysticRunes/PlayedApple.swift
+++ b/PlayTools/MysticRunes/PlayedApple.swift
@@ -258,6 +258,12 @@ public class PlayKeychain: NSObject {
             debugLogger("Failed to generate key pair.")
             return errSecMissingEntitlement
         }
+        if let newPublicKey = newPublicKey {
+            publicKey?.pointee = Unmanaged.passRetained(newPublicKey)
+        }
+        if let newPrivateKey = newPrivateKey {
+            privateKey?.pointee = Unmanaged.passRetained(newPrivateKey)
+        }
         if isPrivatePermanent {
             // Add the keys to the keychain db with the original attributes
             let publicKeyRef = newPublicKey

--- a/PlayTools/MysticRunes/PlayedApple.swift
+++ b/PlayTools/MysticRunes/PlayedApple.swift
@@ -235,21 +235,26 @@ public class PlayKeychain: NSObject {
         return Unmanaged.passRetained(key)
     }
 
+    // swiftlint:disable:next function_body_length
     @objc static public func keyGeneratePair(_ parameters: NSDictionary,
                                              publicKey: UnsafeMutablePointer<Unmanaged<SecKey>?>?,
                                              privateKey: UnsafeMutablePointer<Unmanaged<SecKey>?>?) -> OSStatus {
         // Same as above but we need to disable kSecAttrIsPermanent for both the public and private key.
+        var isPermanent = parameters[kSecAttrIsPermanent as String] as? Bool ?? false
         var privateKeyAttrs = parameters[kSecPrivateKeyAttrs as String] as? [String: Any] ?? [:]
         let isPrivatePermanent = privateKeyAttrs[kSecAttrIsPermanent as String] as? Bool ?? false
         if isPrivatePermanent {
             privateKeyAttrs[kSecAttrIsPermanent as String] = false
+            isPermanent = true
         }
         var publicKeyAttrs = parameters[kSecPublicKeyAttrs as String] as? [String: Any] ?? [:]
         let isPublicPermanent = (publicKeyAttrs[kSecAttrIsPermanent as String] as? Bool) ?? false
         if isPublicPermanent {
             publicKeyAttrs[kSecAttrIsPermanent as String] = false
+            isPermanent = true
         }
         var parametersCopy = parameters as! [String: Any] // swiftlint:disable:this force_cast
+        parametersCopy.removeValue(forKey: kSecAttrIsPermanent as String)
         parametersCopy[kSecPrivateKeyAttrs as String] = privateKeyAttrs
         parametersCopy[kSecPublicKeyAttrs as String] = publicKeyAttrs
         var newPublicKey: SecKey?
@@ -264,7 +269,7 @@ public class PlayKeychain: NSObject {
         if let newPrivateKey = newPrivateKey {
             privateKey?.pointee = Unmanaged.passRetained(newPrivateKey)
         }
-        if isPrivatePermanent {
+        if isPermanent {
             // Add the keys to the keychain db with the original attributes
             let publicKeyRef = newPublicKey
             let privateKeyRef = newPrivateKey

--- a/PlayTools/MysticRunes/PlayedApple.swift
+++ b/PlayTools/MysticRunes/PlayedApple.swift
@@ -254,7 +254,7 @@ public class PlayKeychain: NSObject {
         parametersCopy[kSecPublicKeyAttrs as String] = publicKeyAttrs
         var newPublicKey: SecKey?
         var newPrivateKey: SecKey?
-        guard SecKeyGeneratePair(parametersCopy as CFDictionary, &newPublicKey, &newPrivateKey) != 0 else {
+        guard SecKeyGeneratePair(parametersCopy as CFDictionary, &newPublicKey, &newPrivateKey) == 0 else {
             debugLogger("Failed to generate key pair.")
             return errSecMissingEntitlement
         }


### PR DESCRIPTION
Fixed several issues in PlayChain’s SecKeyGeneratePair implementation.
The changes are split into separate commits for clarity, they can be squashed.

**First Issue**
There is a mistake in the guard statement. The success check should be `== 0`, not `!= 0`.

**Second issue**
It does not assign the generated keys to the out pointers, so the caller always receives `null` for both keys.

**Third Issue**
The app may place `kSecAttrIsPermanent` ("perm = 1") at the root-level of the parameter dictionary, instead of inside `kSecPrivateKeyAttrs` or `kSecPublicKeyAttrs`. PlayChain should handle this case as well.
<br/>

<img width="700" src="https://github.com/user-attachments/assets/d859a565-0671-448f-8276-8a3bccbd6900" />
