### PR TITLE
fix: preserve Metal HUD menu after menu rebuild

### DIFF
--- a/PlayTools/Controls/MenuController.swift
+++ b/PlayTools/Controls/MenuController.swift
@@ -179,10 +179,16 @@ class MenuController {
             // Delay to avoid error
             // Cannot set a main menu system configuration while the main menu system is building.
             DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+                PTPreserveMetalHUDMenuItem()
                 let configuration = UIMainMenuSystem.Configuration()
                 configuration.sidebarPreference = .included
                 UIMainMenuSystem.shared.setBuildConfiguration(configuration) { builder in
+                    PTPreserveMetalHUDMenuItem()
                     self.setupMenu(with: builder)
+                    // Defer restoration until AppKit has installed the rebuilt main menu.
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                        PTRestoreMetalHUDMenuItem()
+                    }
                 }
             }
         } else {

--- a/PlayTools/Controls/PTFakeTouch/NSObject+Swizzle.m
+++ b/PlayTools/Controls/PTFakeTouch/NSObject+Swizzle.m
@@ -7,6 +7,7 @@
 
 #import "NSObject+Swizzle.h"
 #import <objc/runtime.h>
+#import <objc/message.h>
 #import "CoreGraphics/CoreGraphics.h"
 #import "UIKit/UIKit.h"
 #import <PlayTools/PlayTools-Swift.h>
@@ -19,6 +20,66 @@
 __attribute__((visibility("hidden")))
 @interface PTSwizzleLoader : NSObject
 @end
+
+static id preservedMetalHUDMenuItem = nil;
+
+static id PTMessageObject(id object, SEL selector) {
+    if (object == nil || ![object respondsToSelector:selector]) {
+        return nil;
+    }
+    return ((id (*)(id, SEL))objc_msgSend)(object, selector);
+}
+
+static id PTMainMenu(void) {
+    Class applicationClass = NSClassFromString(@"NSApplication");
+    id application = PTMessageObject(applicationClass, NSSelectorFromString(@"sharedApplication"));
+    return PTMessageObject(application, NSSelectorFromString(@"mainMenu"));
+}
+
+static id PTMetalHUDMenuItem(id mainMenu) {
+    NSArray *items = PTMessageObject(mainMenu, NSSelectorFromString(@"itemArray"));
+    for (id item in items) {
+        NSString *title = PTMessageObject(item, NSSelectorFromString(@"title"));
+        if ([title isEqualToString:@"Metal HUD"]) {
+            return item;
+        }
+    }
+    return nil;
+}
+
+void PTPreserveMetalHUDMenuItem(void) {
+    id item = PTMetalHUDMenuItem(PTMainMenu());
+    if (item != nil) {
+        preservedMetalHUDMenuItem = item;
+    }
+}
+
+void PTRestoreMetalHUDMenuItem(void) {
+    id mainMenu = PTMainMenu();
+    if (mainMenu == nil || preservedMetalHUDMenuItem == nil) {
+        return;
+    }
+
+    id currentItem = PTMetalHUDMenuItem(mainMenu);
+    if (currentItem != nil) {
+        preservedMetalHUDMenuItem = currentItem;
+        return;
+    }
+
+    id previousMenu = PTMessageObject(preservedMetalHUDMenuItem, NSSelectorFromString(@"menu"));
+    if (previousMenu != nil) {
+        ((void (*)(id, SEL, id))objc_msgSend)(
+            previousMenu,
+            NSSelectorFromString(@"removeItem:"),
+            preservedMetalHUDMenuItem
+        );
+    }
+    ((void (*)(id, SEL, id))objc_msgSend)(
+        mainMenu,
+        NSSelectorFromString(@"addItem:"),
+        preservedMetalHUDMenuItem
+    );
+}
 
 @implementation NSObject (Swizzle)
 

--- a/PlayTools/PlayTools.h
+++ b/PlayTools/PlayTools.h
@@ -21,3 +21,7 @@ FOUNDATION_EXPORT const unsigned char PlayToolsVersionString[];
 // This is the function that CFRunLoop calls to serve main dispatch queue
 // Used by PlayInput to manually drain the queue
 extern void _dispatch_main_queue_callback_4CF(void *);
+
+// Preserve the Metal HUD menu across UIKit main-menu rebuilds on macOS.
+void PTPreserveMetalHUDMenuItem(void);
+void PTRestoreMetalHUDMenuItem(void);


### PR DESCRIPTION
## Summary

- preserve the system-provided Metal HUD menu item before UIKit rebuilds the main menu
- restore the item after AppKit installs the rebuilt menu
- access AppKit dynamically so PlayTools continues to build for iOS

## Testing

- built the PlayTools Release scheme for a generic iOS device with code signing disabled
- verified in Arknights: Endfield on macOS 26 that the Metal HUD menu remains available after PlayTools installs its key-mapping menus
