### PR TITLE
fix: synchronize sleep-spam tracking state

### DIFF
--- a/PlayTools/PlayLoader.m
+++ b/PlayTools/PlayLoader.m
@@ -281,25 +281,29 @@ static int pt_usleep(useconds_t time) {
     if ([[PlaySettings shared] blockSleepSpamming]) {
         int thread_id = pthread_mach_thread_np(pthread_self());
         NSNumber *threadKey = @(thread_id);
-        
-        int thread_sleep_counter = [thread_sleep_counters[threadKey] intValue];
-        int last_sleep_attempt = [last_sleep_attempts[threadKey] intValue];
-        
-        if (time == 100000) {
-            int timestamp = (int)[[NSDate date] timeIntervalSince1970];
-            // If it sleeps too fast, increase counter
-            if (timestamp - last_sleep_attempt < 2) {
-                thread_sleep_counter++;
-            } else {
-                thread_sleep_counter = 1;
+
+        BOOL exceeded_sleep_limit = NO;
+        @synchronized (thread_sleep_counters) {
+            int thread_sleep_counter = [thread_sleep_counters[threadKey] intValue];
+            int last_sleep_attempt = [last_sleep_attempts[threadKey] intValue];
+
+            if (time == 100000) {
+                int timestamp = (int)[[NSDate date] timeIntervalSince1970];
+                // If it sleeps too fast, increase counter
+                if (timestamp - last_sleep_attempt < 2) {
+                    thread_sleep_counter++;
+                } else {
+                    thread_sleep_counter = 1;
+                }
+                last_sleep_attempt = timestamp;
+                thread_sleep_counters[threadKey] = @(thread_sleep_counter);
+                last_sleep_attempts[threadKey] = @(last_sleep_attempt);
             }
-            last_sleep_attempt = timestamp;
-            thread_sleep_counters[threadKey] = @(thread_sleep_counter);
-            last_sleep_attempts[threadKey] = @(last_sleep_attempt);
-            
+
+            exceeded_sleep_limit = thread_sleep_counter > 100;
         }
-        
-        if (thread_sleep_counter > 100) {
+
+        if (exceeded_sleep_limit) {
             // Stop this thread from spamming usleep calls
             NSLog(@"[PC] Thread %i exceeded usleep limit. Seem sus, stopping this "
                   @"thread FOREVER",


### PR DESCRIPTION
## Summary

- synchronize access to the shared sleep-spam tracking dictionaries
- keep the counter update and threshold check in the same critical section

## Root cause

`pt_usleep` can run concurrently on multiple game threads while `blockSleepSpamming` is enabled. The shared `NSMutableDictionary` instances were read and mutated without synchronization. Concurrent access could corrupt their internal storage during insertion or rehashing and crash the game from `pt_usleep`.

## Impact

This preserves the existing sleep-spam detection behavior while preventing dictionary access races during game startup and runtime.

## Testing

- built the PlayTools Release scheme for a generic iOS device with code signing disabled
- verified the synchronization fix in Arknights: Endfield on macOS 26 with sleep-spam blocking enabled
