### PR TITLE
fix: remove deadlock in pt_usleep sleep-spam blocker (can hang render thread → os_unfair_lock crash)

### DIFF
--- a/PlayTools/PlayLoader.m
+++ b/PlayTools/PlayLoader.m
@@ -331,14 +331,11 @@ static int pt_unlink(char const* path) {
 static NSMutableDictionary *thread_sleep_counters = nil;
 static NSMutableDictionary *last_sleep_attempts = nil;
 static dispatch_once_t thread_sleep_once;
-static NSLock *thread_sleep_lock = nil;
 
 static int pt_usleep(useconds_t time) {
     dispatch_once(&thread_sleep_once, ^{
         thread_sleep_counters = [NSMutableDictionary dictionary];
         last_sleep_attempts = [NSMutableDictionary dictionary];
-        thread_sleep_lock = [[NSLock alloc] init];
-        [thread_sleep_lock lock];
     });
     
     if ([[PlaySettings shared] blockSleepSpamming]) {
@@ -367,14 +364,10 @@ static int pt_usleep(useconds_t time) {
         }
 
         if (exceeded_sleep_limit) {
-            // Stop this thread from spamming usleep calls
-            NSLog(@"[PC] Thread %i exceeded usleep limit. Seem sus, stopping this "
-                  @"thread FOREVER",
-                  thread_id);
-            
-            [thread_sleep_lock lock];
-            [thread_sleep_lock unlock];
-            
+            // Stop this thread from spamming usleep calls by skipping the sleep.
+            // Do NOT block/hang the thread: hanging a render/GPU thread here is what
+            // caused os_unfair_lock corruption and crashes in Unity games (e.g. Endfield).
+            NSLog(@"[PC] Thread %i exceeded usleep limit. Skipping its sleeps.", thread_id);
             return 0;
         }
     }
@@ -403,16 +396,6 @@ static void __attribute__((constructor)) initialize(void) {
     
     if (ue_status == 2) {
         [PlayKeychain debugLogger: [NSString stringWithFormat:@"UnrealEngine Hooked"]];
-    }
-
-    if ([[PlaySettings shared] blockSleepSpamming]) {
-        // Add an observer so we can unlock threads on app termination
-        [[NSNotificationCenter defaultCenter] addObserverForName:UIApplicationWillTerminateNotification
-                                                          object:nil
-                                                           queue:[NSOperationQueue mainQueue]
-                                                      usingBlock:^(NSNotification * _Nonnull note) {
-            [thread_sleep_lock unlock];
-        }];
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes a deadlock in the `pt_usleep` sleep-spam blocker (`blockSleepSpamming` toggle) that can hang a thread forever — and, when the hung thread is a render/GPU thread, corrupts `os_unfair_lock` and crashes the game.

## The bug

In `PlayTools/PlayLoader.m`, `pt_usleep`:

```objc
static int pt_usleep(useconds_t time) {
    dispatch_once(&thread_sleep_once, ^{
        ...
        thread_sleep_lock = [[NSLock alloc] init];
        [thread_sleep_lock lock];      // (1) LOCKED inside dispatch_once, never unlocked
    });

    if ([[PlaySettings shared] blockSleepSpamming]) {
        ...
        if (exceeded_sleep_limit) {     // >100× usleep(100000) within 2s
            [thread_sleep_lock lock];   // (2) NSLock is NOT recursive → DEADLOCK forever
            [thread_sleep_lock unlock]; //     never reached
            return 0;                   //     never reached
        }
    }
    return usleep(time);
}
```

- `NSLock` is **not recursive**: the lock taken inside `dispatch_once` (1) is held forever, so the second `lock` (2) blocks the thread **permanently** instead of "stopping" it.
- If that thread is `UnityGfxDeviceWorker` / a render thread / the main thread, the render pipeline hangs → `os_unfair_lock` corruption → crash.
- This matches the crash signature reported for Arknights: Endfield (`BUG IN CLIENT OF LIBPLATFORM: Trying to recursively lock an os_unfair_lock`, `EXC_BREAKPOINT`/`SIGKILL`), see PlayCover/PlayCover#2067 and PlayCover/PlayCover#2202.

## The fix

- Remove the deadlocking `thread_sleep_lock` entirely. The per-thread counter is already protected by `@synchronized(thread_sleep_counters)`.
- When a thread exceeds the usleep limit, **skip its sleeps** (`return 0`) instead of hanging it — same anti-spam effect, no deadlock.
- Remove the now-unneeded `UIApplicationWillTerminateNotification` observer that unlocked the (now removed) lock.

## Testing

- Brace/paren balance verified; the change is purely deletion of the lock + its observer.
- Could not run a full `xcodebuild` here (no iOS SDK toolchain available in this environment); the diff is minimal and self-contained.
- Recommended verification: build PlayTools, install, enable `blockSleepSpamming` in a Unity game (e.g. Endfield), and confirm the game no longer hangs/crashes after ~60s.

## Related

- PlayCover/PlayCover#2067 — "Arknights: Endfield GPU-related thread lock corruption causes crash"
- PlayCover/PlayCover#2202 — "Arknights Endfield 1.4.3 silent-exits after ~60s" (fresh M3 data)