### PR TITLE
Revert "Fix hard coded user dir path"

### DIFF
--- a/AKPlugin.swift
+++ b/AKPlugin.swift
@@ -18,23 +18,6 @@ private struct AKAppSettingsData: Codable {
     var resizableAspectRatioHeight: Int?
 }
 
-private func akCurrentUserHomeDirectoryPath() -> String {
-    let userName = NSUserName()
-    if let homeDirectory = NSHomeDirectoryForUser(userName) {
-        return homeDirectory
-    }
-    return NSString(string: "~\(userName)").expandingTildeInPath
-}
-
-private func akSettingsURLForBundleIdentifier(_ bundleIdentifier: String) -> URL {
-    return URL(fileURLWithPath: akCurrentUserHomeDirectoryPath(), isDirectory: true)
-        .appendingPathComponent("Library", isDirectory: true)
-        .appendingPathComponent("Containers", isDirectory: true)
-        .appendingPathComponent("io.playcover.PlayCover", isDirectory: true)
-        .appendingPathComponent("App Settings")
-        .appendingPathComponent("\(bundleIdentifier).plist")
-}
-
 class AKPlugin: NSObject, Plugin {
     required override init() {
         super.init()
@@ -321,7 +304,9 @@ class AKPlugin: NSObject, Plugin {
 
     fileprivate static var akAppSettingsData: AKAppSettingsData? = {
         let bundleIdentifier = Bundle.main.bundleIdentifier ?? ""
-        let settingsURL = akSettingsURLForBundleIdentifier(bundleIdentifier)
+        let settingsURL = URL(fileURLWithPath: "/Users/\(NSUserName())/Library/Containers/io.playcover.PlayCover")
+            .appendingPathComponent("App Settings")
+            .appendingPathComponent("\(bundleIdentifier).plist")
         guard let data = try? Data(contentsOf: settingsURL),
               let decoded = try? PropertyListDecoder().decode(AKAppSettingsData.self, from: data) else {
             return nil

--- a/PlayTools/MysticRunes/PlayedAppleDB.swift
+++ b/PlayTools/MysticRunes/PlayedAppleDB.swift
@@ -238,7 +238,7 @@ class PlayKeychainDB: NSObject {
     private func connectToDB() -> OpaquePointer? {
         var sqlite3DB: OpaquePointer?
         let bundleID = Bundle.main.infoDictionary?["CFBundleIdentifier"] as? String ?? "Shared"
-        let keychainDB = playCoverContainerBaseURL()
+        let keychainDB = URL(fileURLWithPath: "/Users/\(NSUserName())/Library/Containers/io.playcover.PlayCover")
             .appendingPathComponent("PlayChain")
             .appendingPathComponent("\(bundleID).db")
 

--- a/PlayTools/PlayLoader.m
+++ b/PlayTools/PlayLoader.m
@@ -5,8 +5,6 @@
 
 #include <Foundation/Foundation.h>
 #include <errno.h>
-#include <limits.h>
-#include <stdatomic.h>
 #include <sys/sysctl.h>
 
 #import "PlayLoader.h"
@@ -218,75 +216,14 @@ DYLD_INTERPOSE(pt_SecKeyGeneratePair, SecKeyGeneratePair)
 
 static uint8_t ue_status = 0;
 
-static void pt_copyCurrentUserHomeDirectory(char *buffer, size_t bufferSize) {
-    if (bufferSize == 0) {
-        return;
-    }
-
-    buffer[0] = '\0';
-
-    char executablePath[PATH_MAX];
-    uint32_t executablePathSize = sizeof(executablePath);
-    if (_NSGetExecutablePath(executablePath, &executablePathSize) == 0) {
-        static char const containerMarker[] = "/Library/Containers/io.playcover.PlayCover/";
-        char *marker = strstr(executablePath, containerMarker);
-        if (marker != NULL) {
-            size_t homePathLength = (size_t)(marker - executablePath);
-            if (homePathLength > 0 && homePathLength < bufferSize) {
-                memcpy(buffer, executablePath, homePathLength);
-                buffer[homePathLength] = '\0';
-                return;
-            }
-        }
-    }
-
-    char const *homeDirectory = getenv("HOME");
-    if (homeDirectory != NULL && homeDirectory[0] != '\0') {
-        static char const containerSuffix[] = "/Library/Containers/io.playcover.PlayCover";
-        char const *suffix = strstr(homeDirectory, containerSuffix);
-        if (suffix != NULL) {
-            size_t homePathLength = (size_t)(suffix - homeDirectory);
-            if (homePathLength > 0 && homePathLength < bufferSize) {
-                memcpy(buffer, homeDirectory, homePathLength);
-                buffer[homePathLength] = '\0';
-                return;
-            }
-        }
-
-        snprintf(buffer, bufferSize, "%s", homeDirectory);
-        return;
-    }
-
-    char userName[256];
-    if (getlogin_r(userName, sizeof(userName)) == 0) {
-        snprintf(buffer, bufferSize, "/Users/%s", userName);
-    }
-}
-
 static char const* ue_fix_filename(char const* filename) {
-    static char uePattern[PATH_MAX];
-    static atomic_int uePatternState = 0; // 0 = uninitialized, 1 = initializing, 2 = ready, 3 = unavailable
-    int expectedState = 0;
-    if (atomic_compare_exchange_strong(&uePatternState, &expectedState, 1)) {
-        char homePath[PATH_MAX];
-        pt_copyCurrentUserHomeDirectory(homePath, sizeof(homePath));
-        if (homePath[0] != '\0') {
-            snprintf(uePattern, sizeof(uePattern), "/%s", homePath);
-            atomic_store(&uePatternState, 2);
-        } else {
-            atomic_store(&uePatternState, 3);
-        }
-    }
-
-    int patternState = atomic_load(&uePatternState);
-    if (patternState != 2 || uePattern[0] == '\0') {
-        return filename;
-    }
+    static char UE_PATTERN[1024] = "//Users/";
+    getlogin_r(UE_PATTERN + 8, sizeof(UE_PATTERN) - 8);
     
     char const* p = filename;
     if (ue_status == 2) {
         char const* last_p = p;
-        while ((p = strstr(p, uePattern))) {
+        while ((p = strstr(p, UE_PATTERN))) {
             last_p = ++p;
         }
         

--- a/PlayTools/PlaySettings.swift
+++ b/PlayTools/PlaySettings.swift
@@ -3,21 +3,6 @@ import UIKit
 
 let settings = PlaySettings.shared
 
-func playCoverUserHomeDirectoryPath() -> String {
-    let userName = NSUserName()
-    if let homeDirectory = NSHomeDirectoryForUser(userName) {
-        return homeDirectory
-    }
-    return NSString(string: "~\(userName)").expandingTildeInPath
-}
-
-func playCoverContainerBaseURL() -> URL {
-    URL(fileURLWithPath: playCoverUserHomeDirectoryPath(), isDirectory: true)
-        .appendingPathComponent("Library", isDirectory: true)
-        .appendingPathComponent("Containers", isDirectory: true)
-        .appendingPathComponent("io.playcover.PlayCover", isDirectory: true)
-}
-
 @objc public final class PlaySettings: NSObject {
     @objc public static let shared = PlaySettings()
 
@@ -26,7 +11,7 @@ func playCoverContainerBaseURL() -> URL {
     var settingsData: AppSettingsData
 
     override init() {
-        settingsUrl = playCoverContainerBaseURL()
+        settingsUrl = URL(fileURLWithPath: "/Users/\(NSUserName())/Library/Containers/io.playcover.PlayCover")
             .appendingPathComponent("App Settings")
             .appendingPathComponent("\(bundleIdentifier).plist")
         do {


### PR DESCRIPTION
Reverts PlayCover/PlayTools#221

Fixes https://github.com/PlayCover/PlayCover/issues/2213, https://github.com/PlayCover/PlayCover/issues/2201

This should be reverted in the mean time as it breaks all PlayTools settings due to PlayTools retrieving sandboxed user path, resulting in the failure to resolve PlayTools configurations. Note that other downstream forks of PlayTools have also reverted this fix.